### PR TITLE
docs: vite uses `VITE_` prefix

### DIFF
--- a/docs/src/app/docs/core/page.mdx
+++ b/docs/src/app/docs/core/page.mdx
@@ -1,6 +1,6 @@
 # Core
 
-The core package can be used in any framework of your choice. To use it, figure out what prefix your framework uses for exposing environment variables to the client. For example, Astro uses `PUBLIC_`, while Vite uses `VITE_PUBLIC`. You should be able to find this in the frameworks documentation.
+The core package can be used in any framework of your choice. To use it, figure out what prefix your framework uses for exposing environment variables to the client. For example, Astro uses `PUBLIC_`, while Vite uses `VITE_`. You should be able to find this in the frameworks documentation.
 
 Then, you can create your schema like so:
 


### PR DESCRIPTION
see https://vitejs.dev/guide/env-and-mode.html#env-files