### PR TITLE
fix: add types to package.json#exports

### DIFF
--- a/.changeset/four-pears-divide.md
+++ b/.changeset/four-pears-divide.md
@@ -1,0 +1,6 @@
+---
+"@t3-oss/env-nextjs": patch
+"@t3-oss/env-core": patch
+---
+
+add types to package.json exports map

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -19,6 +19,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },


### PR DESCRIPTION
without this, types were not picked up for me when `tsconfig.json#moduleResolution` was set to `nodenext`.