### PR TITLE
Change `src/env.ts` to `src/env.mjs`

### DIFF
--- a/docs/src/app/docs/core/page.mdx
+++ b/docs/src/app/docs/core/page.mdx
@@ -4,7 +4,7 @@ The core package can be used in any framework of your choice. To use it, figure 
 
 Then, you can create your schema like so:
 
-```ts title="src/env.ts"
+```ts title="src/env.mjs"
 import { createEnv } from "@t3-oss/env-core";
 
 export const env = createEnv({
@@ -52,7 +52,7 @@ Exactly one of `runtimeEnv` and `runtimeEnvStrict` should be specified.
 
 If your framework doesn't bundle all environment variables by default, but instead only bundles the ones you use, you can use the `runtimeEnvStrict` option to make sure you don't forget to add any variables to your runtime.
 
-```ts title="src/env.ts"
+```ts title="src/env.mjs"
 import { createEnv } from "@t3-oss/env-core";
 
 export const env = createEnv({

--- a/docs/src/app/docs/customization/page.mdx
+++ b/docs/src/app/docs/customization/page.mdx
@@ -4,7 +4,7 @@ Below are some examples of how you can customize the behavior of the library. Th
 
 ## Skipping validation
 
-```ts title="src/env.ts"
+```ts title="src/env.mjs"
 import { createEnv } from "@t3-oss/env-core";
 
 export const env = createEnv({
@@ -19,7 +19,7 @@ export const env = createEnv({
 
 ## Overriding the default error handler
 
-```ts title="src/env.ts"
+```ts title="src/env.mjs"
 import { createEnv } from "@t3-oss/env-core";
 
 export const env = createEnv({
@@ -43,7 +43,7 @@ export const env = createEnv({
 
 ## Tell when we're in a server context
 
-```ts title="src/env.ts"
+```ts title="src/env.mjs"
 import { createEnv } from "@t3-oss/env-core";
 
 export const env = createEnv({

--- a/docs/src/app/docs/installation/page.mdx
+++ b/docs/src/app/docs/installation/page.mdx
@@ -25,7 +25,7 @@ pnpm add @t3-oss/env-nextjs zod
 
 Create a file `env.ts` in your project and define your schema:
 
-```ts title="src/env.ts"
+```ts title="src/env.mjs"
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 


### PR DESCRIPTION
As we have to import `env.ts` in `next.config.js` for runtime type validation check and next still now don't support ts extension for their config file, so we must have to make `env.mjs`. That is why I changed extension from doc. 