### PR TITLE
docs: fix overlapping copy to clipboard button

### DIFF
--- a/docs/src/components/mdx/code-block.tsx
+++ b/docs/src/components/mdx/code-block.tsx
@@ -10,6 +10,7 @@ export function Codeblock(
 ) {
   const { children, ...rest } = props;
   const language = props["data-language" as keyof typeof props] as string;
+  const theme = props["data-theme" as keyof typeof props] as string;
   const Icon = {
     js: Icons.javascript,
     ts: Icons.typescript,
@@ -24,31 +25,36 @@ export function Codeblock(
       {Icon && (
         <Icon
           data-language-icon
+          data-theme={theme}
           className="absolute left-4 top-4 z-20 hidden h-5 w-5 text-foreground"
         />
       )}
-      <div
+      <button
+        aria-label="Copy to Clipboard"
+        data-theme={theme}
         onClick={() => {
           if (typeof window === "undefined" || !ref.current) return;
           setCopied(true);
           void window.navigator.clipboard.writeText(ref.current.innerText);
           setTimeout(() => setCopied(false), 1500);
         }}
-        className="absolute right-2 top-[10px] z-20 h-8 w-8 cursor-pointer rounded p-1 text-muted-foreground hover:bg-muted"
+        className="absolute right-2 top-[10px] z-20 h-8 w-8 cursor-pointer rounded text-muted-foreground hover:bg-muted"
       >
-        <Copy
-          className={cn(
-            "absolute h-6 w-6 p-0 transition-all",
-            copied && "scale-0"
-          )}
-        />
-        <CheckCheck
-          className={cn(
-            "absolute h-6 w-6 scale-0 p-1 transition-all",
-            copied && "scale-100"
-          )}
-        />
-      </div>
+        <div className="relative p-1 w-full h-full">
+          <Copy
+            className={cn(
+              "absolute h-6 w-6 p-0 transition-all",
+              copied && "scale-0"
+            )}
+          />
+          <CheckCheck
+            className={cn(
+              "absolute h-6 w-6 scale-0 p-0 transition-all",
+              copied && "scale-100"
+            )}
+          />
+        </div>
+      </button>
       <pre
         ref={ref}
         className="relative my-4 overflow-x-scroll rounded-lg border bg-muted p-4 font-mono text-sm font-semibold text-muted-foreground"

--- a/docs/src/components/mdx/code-block.tsx
+++ b/docs/src/components/mdx/code-block.tsx
@@ -1,16 +1,24 @@
 "use client";
 
-import { useRef, useState, type DetailedHTMLProps } from "react";
+import { useRef, useState } from "react";
 import { CheckCheck, Copy } from "lucide-react";
 import { Icons } from "../icons";
 import { cn } from "@/lib/cn";
 
-export function Codeblock(
-  props: DetailedHTMLProps<React.HTMLAttributes<HTMLPreElement>, HTMLPreElement>
-) {
+export type CodeblockProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLPreElement>,
+  HTMLPreElement
+> & {
+  /** set by `rehype-pretty-code` */
+  "data-language"?: string;
+  /** set by `rehype-pretty-code` */
+  "data-theme"?: string;
+};
+
+export function Codeblock(props: CodeblockProps) {
   const { children, ...rest } = props;
-  const language = props["data-language" as keyof typeof props] as string;
-  const theme = props["data-theme" as keyof typeof props] as string;
+  const language = props["data-language"] as string;
+  const theme = props["data-theme"] as string;
   const Icon = {
     js: Icons.javascript,
     ts: Icons.typescript,

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -159,15 +159,11 @@
     @apply mt-0 rounded-t-none;
   }
 
-  pre[data-theme="light"],
-  code[data-theme="light"],
-  [data-rehype-pretty-code-title][data-theme="light"] {
+  [data-theme="light"] {
     @apply block dark:hidden;
   }
 
-  pre[data-theme="dark"],
-  code[data-theme="dark"],
-  [data-rehype-pretty-code-title][data-theme="dark"] {
+  [data-theme="dark"] {
     @apply hidden dark:block;
   }
 }


### PR DESCRIPTION
The 'copy to clipboard' button shown in code blocks shows overlapping icons when `copied` is `true`.

This is because [Rehype Pretty Code](https://rehype-pretty-code.netlify.app) renders the `<pre>` element twice when both a `light` and `dark` theme have been configured. Since this project appends the 'copy to clipboard' button to `<pre>`, two are rendered for each code block.

**The solution:**

- Add `data-theme` to each 'copy to clipboard' button (and to the language icon for good measure)
- Hide all elements where `[data-theme="not the current theme"]`
- Remove the unnecessary `p-1` on the `CheckCheck` icon

This PR also changes the button from a `<div>` to an actual `<button>` with an `aria-label`

**Before:**


https://user-images.githubusercontent.com/13686180/235287268-ecddd5fe-3104-4602-a9eb-8e9c50cb159f.mov



**After:**


https://user-images.githubusercontent.com/13686180/235287269-cf70325d-b1a0-404d-9a29-8b7c032a5875.mov

