### PR TITLE
Remove `process.env` usage from the core

### DIFF
--- a/.changeset/sour-laws-allow.md
+++ b/.changeset/sour-laws-allow.md
@@ -1,0 +1,5 @@
+---
+"@t3-oss/env-core": patch
+---
+
+Remove process.env usage

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -50,7 +50,7 @@ export interface BaseOptions<
 
   /**
    * Whether to skip validation of environment variables.
-   * @default !!process.env.SKIP_ENV_VALIDATION && process.env.SKIP_ENV_VALIDATION !== "false" && process.env.SKIP_ENV_VALIDATION !== "0"
+   * @default false
    */
   skipValidation?: boolean;
 }
@@ -100,11 +100,7 @@ export function createEnv<
 ): z.infer<ZodObject<TServer>> & z.infer<ZodObject<TClient>> {
   const runtimeEnv = opts.runtimeEnvStrict ?? opts.runtimeEnv ?? process.env;
 
-  const skip =
-    opts.skipValidation ??
-    (!!process.env.SKIP_ENV_VALIDATION &&
-      process.env.SKIP_ENV_VALIDATION !== "false" &&
-      process.env.SKIP_ENV_VALIDATION !== "0");
+  const skip = !!opts.skipValidation;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
   if (skip) return runtimeEnv as any;
 


### PR DESCRIPTION
If we try to use this package in Vite (SPA) project, it will throw an error `Uncaught ReferenceError: process is not defined` on client-side, as Vite is using `import.meta.env` instead of `process.env`. 

So, the fix is to remove all the existing `process.env` usage.

> Note that Astro is an exception, as most of the code are run/build in Node runtime, which the `process.env` is always available.