### PR TITLE
Codeblock language icon fix

### DIFF
--- a/.changeset/thin-bats-relax.md
+++ b/.changeset/thin-bats-relax.md
@@ -1,0 +1,5 @@
+---
+"@t3-env/docs": patch
+---
+
+Fix overlapping codeblock icon

--- a/.changeset/thin-bats-relax.md
+++ b/.changeset/thin-bats-relax.md
@@ -1,5 +1,0 @@
----
-"@t3-env/docs": patch
----
-
-Fix overlapping codeblock icon

--- a/docs/src/components/mdx/code-block.tsx
+++ b/docs/src/components/mdx/code-block.tsx
@@ -34,7 +34,7 @@ export function Codeblock(props: CodeblockProps) {
         <Icon
           data-language-icon
           data-theme={theme}
-          className="absolute left-4 top-4 z-20 hidden h-5 w-5 text-foreground"
+          className="absolute left-4 top-4 z-20 h-5 w-5 text-foreground"
         />
       )}
       <button

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -142,6 +142,10 @@
     @apply relative;
   }
 
+  [data-language-icon] {
+    @apply hidden dark:hidden;
+  }
+
   [data-rehype-pretty-code-title] {
     padding: 0.75rem 0 0.75rem 2.5rem;
     @apply mt-4 rounded-t-lg border border-b-0 bg-accent font-cal;
@@ -151,19 +155,23 @@
     @apply pl-12;
   }
 
-  [data-rehype-pretty-code-title] ~ [data-language-icon] {
-    @apply block;
-  }
-
   [data-rehype-pretty-code-title] ~ pre {
     @apply mt-0 rounded-t-none;
   }
 
-  [data-theme="light"] {
+  [data-rehype-pretty-code-title] ~ [data-language-icon][data-theme="light"] {
     @apply block dark:hidden;
   }
 
-  [data-theme="dark"] {
+  [data-rehype-pretty-code-title] ~ [data-language-icon][data-theme="dark"] {
+    @apply hidden dark:block;
+  }
+
+  [data-theme="light"]:not([data-language-icon]) {
+    @apply block dark:hidden;
+  }
+
+  [data-theme="dark"]:not([data-language-icon]) {
     @apply hidden dark:block;
   }
 }

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -143,7 +143,7 @@
   }
 
   [data-language-icon] {
-    @apply hidden dark:hidden;
+    @apply hidden;
   }
 
   [data-rehype-pretty-code-title] {


### PR DESCRIPTION
Fix #34 

Fixed codeblock overlapping icon caused by the recent fix from #32. 

As the CSS fix from #32 (shown below), will always apply to element that has `data-theme`.
```css
[data-theme="light"] {
  @apply block dark:hidden;
}

[data-theme="dark"] {
  @apply hidden dark:block;
}
``` 

However, the language icon works slightly different, where the icon will only show if the title is present. So, the solution is to handle the hide/show separately.