### PR TITLE
chore: next.js example in docs

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -68,7 +68,7 @@ export default config;
 Then, import the `env` object in your application and use it, taking advantage of type-safety and auto-completion:
 
 ```ts title="some-api-endpoint.ts"
-import { env } from "~/env"; // On server
+import { env } from "~/env.mjs"; // On server
 
 export const GET = async () => {
   // do fancy ai stuff
@@ -80,7 +80,7 @@ export const GET = async () => {
 ```
 
 ```ts title="some-component.tsx"
-import { env } from "~/env"; // On client - same import!
+import { env } from "~/env.mjs"; // On client - same import!
 
 export const SomeComponent = () => {
   return (


### PR DESCRIPTION
I was playing around with this lit library today but wasted a few minutes trying to understand what `~/env` meant. I thought it generated type definition files but couldn't get typescript to compile. I updated docs to use `~/env.mjs` instead of `~/env` so people don't get confused thinking like me. 