### PR TITLE
docs: add zod primitives coercion recipes

### DIFF
--- a/docs/src/app/docs/recipes/page.mdx
+++ b/docs/src/app/docs/recipes/page.mdx
@@ -25,6 +25,10 @@ export const env = createEnv({
       .refine((s) => s === "true" || s === "false")
       // transform to boolean
       .transform((s) => s === "true"),
+
+    // Alternatively, use Zod's default primitives coercion
+    // https://zod.dev/?id=coercion-for-primitives
+    ZOD_BOOLEAN_COERCION: z.coerce.boolean(),
   },
   // ...
 });
@@ -43,6 +47,10 @@ export const env = createEnv({
       .transform((s) => parseInt(s, 10))
       // make sure transform worked
       .pipe(z.number()),
+
+    // Alternatively, use Zod's default primitives coercion
+    // https://zod.dev/?id=coercion-for-primitives
+    ZOD_NUMBER_COERCION: z.coerce.number(),
   },
   // ...
 });


### PR DESCRIPTION
Zod has a "new" and more concise api for making type coercions for primitives.

I believe it's better then the actual recipe present in the docs, specially for numbers. But it's also nice to keep the current recipe in the docs because it's a more manual way of doing it and may be useful to someone.

### Current (manual way)
```ts
z.string()
 .transform((s) => parseInt(s, 10))
 .pipe(z.number()),
```

### New
```ts
z.coerce.number()
```