### PR TITLE
Fix main nav active state and bring consistency in the UI

### DIFF
--- a/docs/src/app/docs/layout.tsx
+++ b/docs/src/app/docs/layout.tsx
@@ -6,7 +6,7 @@ import { ReactNode } from "react";
 export default function DocsLayout(props: { children: ReactNode }) {
   return (
     <div className="container flex-1 items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[256px_minmax(0,1fr)] lg:gap-10">
-      <aside className="fixed top-14 z-30 -ml-2 -mr-2 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 overflow-y-auto border-r md:sticky md:block">
+      <aside className="fixed top-[4.0625rem] z-30 -ml-2 -mr-2 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 overflow-y-auto border-r md:sticky md:block">
         <ScrollArea className="py-6 pr-4 lg:py-8">
           <DocsSidebarNav items={siteConfig.sidebarNav} />
         </ScrollArea>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -7,7 +7,7 @@ import { Icons } from "@/components/icons";
 
 export default function IndexPage() {
   return (
-    <section className="container flex flex-col justify-center overflow-hidden items-center min-h-[calc(100vh-4rem)] gap-6 pb-8 pt-6 md:py-10">
+    <section className="container flex flex-col justify-center overflow-hidden items-center min-h-[calc(100vh-4.0625rem)] gap-6 pb-8 pt-6 md:py-10">
       <div className="max-w-5xl space-y-8">
         <h1
           className="font-cal animate-fade-up bg-gradient-to-br from-indigo-700 via-accent-foreground to-fuchsia-500 bg-clip-text text-center text-5xl/[3rem] font-bold text-transparent opacity-0 drop-shadow-sm md:text-7xl/[5rem]"

--- a/docs/src/components/main-nav.tsx
+++ b/docs/src/components/main-nav.tsx
@@ -30,7 +30,7 @@ export function MainNav(props: { items: NavItem[] }) {
                   key={index}
                   href={item.href}
                   className={cn(
-                    "text-muted-foreground text-sm font-medium transition-colors hover:text-accent-foreground",
+                    "text-foreground/60 text-sm font-medium transition-colors hover:text-foreground/80",
                     item.disabled && "cursor-not-allowed opacity-80",
                     item.href === pathname && "text-foreground"
                   )}

--- a/docs/src/components/main-nav.tsx
+++ b/docs/src/components/main-nav.tsx
@@ -30,7 +30,7 @@ export function MainNav(props: { items: NavItem[] }) {
                   key={index}
                   href={item.href}
                   className={cn(
-                    "text-muted-foreground flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background hover:bg-accent hover:text-accent-foreground h-9 px-3",
+                    "text-muted-foreground text-sm font-medium transition-colors hover:text-accent-foreground",
                     item.disabled && "cursor-not-allowed opacity-80",
                     item.href === pathname && "text-foreground"
                   )}

--- a/docs/src/components/main-nav.tsx
+++ b/docs/src/components/main-nav.tsx
@@ -17,7 +17,7 @@ export interface NavItem {
 }
 
 export function MainNav(props: { items: NavItem[] }) {
-  const segment = useSelectedLayoutSegment() ?? "/";
+  const segment = useSelectedLayoutSegment();
 
   return (
     <div className="flex gap-6 md:gap-10">
@@ -32,7 +32,9 @@ export function MainNav(props: { items: NavItem[] }) {
                   className={cn(
                     "text-foreground/60 text-sm font-medium transition-colors hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background rounded-sm",
                     item.disabled && "cursor-not-allowed opacity-80",
-                    item.href.startsWith(`/${segment}`) && "text-foreground"
+                    segment &&
+                      item.href.startsWith(`/${segment}`) &&
+                      "text-foreground"
                   )}
                 >
                   {item.title}

--- a/docs/src/components/main-nav.tsx
+++ b/docs/src/components/main-nav.tsx
@@ -17,7 +17,7 @@ export interface NavItem {
 }
 
 export function MainNav(props: { items: NavItem[] }) {
-  const segment = useSelectedLayoutSegment();
+  const segment = useSelectedLayoutSegment() ?? "/";
 
   return (
     <div className="flex gap-6 md:gap-10">

--- a/docs/src/components/main-nav.tsx
+++ b/docs/src/components/main-nav.tsx
@@ -30,7 +30,7 @@ export function MainNav(props: { items: NavItem[] }) {
                   key={index}
                   href={item.href}
                   className={cn(
-                    "text-foreground/60 text-sm font-medium transition-colors hover:text-foreground/80",
+                    "text-foreground/60 text-sm font-medium transition-colors hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background rounded-sm",
                     item.disabled && "cursor-not-allowed opacity-80",
                     item.href.startsWith(`/${segment}`) && "text-foreground"
                   )}

--- a/docs/src/components/main-nav.tsx
+++ b/docs/src/components/main-nav.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 import { cn } from "@/lib/cn";
 import { Icons } from "@/components/icons";
-import { usePathname } from "next/navigation";
+import { useSelectedLayoutSegment } from "next/navigation";
 
 export interface NavItem {
   title: string;
@@ -17,7 +17,7 @@ export interface NavItem {
 }
 
 export function MainNav(props: { items: NavItem[] }) {
-  const pathname = usePathname();
+  const segment = useSelectedLayoutSegment();
 
   return (
     <div className="flex gap-6 md:gap-10">
@@ -32,7 +32,7 @@ export function MainNav(props: { items: NavItem[] }) {
                   className={cn(
                     "text-foreground/60 text-sm font-medium transition-colors hover:text-foreground/80",
                     item.disabled && "cursor-not-allowed opacity-80",
-                    item.href === pathname && "text-foreground"
+                    item.href.startsWith(`/${segment}`) && "text-foreground"
                   )}
                 >
                   {item.title}

--- a/docs/src/components/mobile-nav.tsx
+++ b/docs/src/components/mobile-nav.tsx
@@ -7,7 +7,6 @@ import { Button } from "./ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { ScrollArea } from "./ui/scroll-area";
 
-import { ThemeToggle } from "./theme-toggle";
 import { NavItem } from "./main-nav";
 import { NestedNavItem } from "./sidebar";
 import { PopoverClose } from "@radix-ui/react-popover";
@@ -72,9 +71,6 @@ export function MobileDropdown(props: {
             </div>
           ))}
         </ScrollArea>
-        <div className="border-t pt-4">
-          <ThemeToggle />
-        </div>
       </PopoverContent>
     </Popover>
   );

--- a/docs/src/components/site-header.tsx
+++ b/docs/src/components/site-header.tsx
@@ -9,11 +9,11 @@ import { MobileDropdown } from "@/components/mobile-nav";
 
 export function SiteHeader() {
   return (
-    <header className="bg-background sticky top-0 z-50 w-full border-b">
+    <header className="bg-background/90 sticky top-0 z-50 w-full border-b backdrop-blur">
       <div className="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0">
         <Link
           href="/"
-          className="items-center space-x-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring ring-offset-background flex h-9 mr-3 px-3"
+          className="items-center space-x-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring ring-offset-background flex h-9 mr-4"
         >
           <Icons.logo className="h-6 w-6" />
           <span className="font-bold text-lg">{siteConfig.name}</span>

--- a/docs/src/components/site-header.tsx
+++ b/docs/src/components/site-header.tsx
@@ -11,26 +11,27 @@ export function SiteHeader() {
   return (
     <header className="bg-background sticky top-0 z-50 w-full border-b">
       <div className="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0">
-        <Link href="/" className="items-center space-x-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring ring-offset-background flex h-9 mr-3 px-3">
+        <Link
+          href="/"
+          className="items-center space-x-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring ring-offset-background flex h-9 mr-3 px-3"
+        >
           <Icons.logo className="h-6 w-6" />
-          <span className="font-bold text-lg">
-            {siteConfig.name}
-          </span>
+          <span className="font-bold text-lg">{siteConfig.name}</span>
         </Link>
 
         <MainNav items={siteConfig.mainNav} />
         <div className="flex flex-1 items-center justify-end space-x-4">
-          <nav className="flex items-center space-x-1">
+          <nav className="flex items-center space-x-2">
             <Link
               href={siteConfig.links.github}
               target="_blank"
               rel="noreferrer"
               className={buttonVariants({
-                size: "sm",
+                size: "icon",
                 variant: "ghost",
               })}
             >
-              <Icons.gitHub className="h-5 w-5" />
+              <Icons.gitHub className="h-6 w-6" />
               <span className="sr-only">GitHub</span>
             </Link>
             {/* <Link

--- a/docs/src/components/site-header.tsx
+++ b/docs/src/components/site-header.tsx
@@ -13,7 +13,7 @@ export function SiteHeader() {
       <div className="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0">
         <Link
           href="/"
-          className="items-center space-x-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring ring-offset-background flex h-9 mr-4"
+          className="items-center space-x-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring ring-offset-background flex h-9 mr-6"
         >
           <Icons.logo className="h-6 w-6" />
           <span className="font-bold text-lg">{siteConfig.name}</span>

--- a/docs/src/components/theme-toggle.tsx
+++ b/docs/src/components/theme-toggle.tsx
@@ -12,11 +12,11 @@ export function ThemeToggle() {
   return (
     <Button
       variant="ghost"
-      size="sm"
+      size="icon"
       onClick={() => setTheme(theme === "light" ? "dark" : "light")}
     >
-      <Icons.sun className="rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <Icons.moon className="absolute rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <Icons.sun className="rotate-0 scale-100 w-6 h-6 transition-all dark:-rotate-90 dark:scale-0" />
+      <Icons.moon className="absolute rotate-90 w-6 h-6 scale-0 transition-all dark:rotate-0 dark:scale-100" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   );

--- a/docs/src/components/ui/button.tsx
+++ b/docs/src/components/ui/button.tsx
@@ -19,9 +19,10 @@ const buttonVariants = cva(
         link: "underline-offset-4 hover:underline text-primary",
       },
       size: {
+        lg: "h-11 px-8 rounded-md",
         default: "h-10 py-2 px-4",
         sm: "h-9 px-3 rounded-md",
-        lg: "h-11 px-8 rounded-md",
+        icon: "p-1",
       },
     },
     defaultVariants: {

--- a/docs/tailwind.config.ts
+++ b/docs/tailwind.config.ts
@@ -7,7 +7,7 @@ export default {
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: "1.5rem",
       screens: {
         "2xl": "1400px",
       },


### PR DESCRIPTION
I've made some minor tweaks and fixed a bug to improve the UX

- Fixed the issue with the main navigation's active state
  - The issue was caused by the `usePathname` hook, which has been resolved
  - I have implemented the `useSelectedLayoutSegment` hook to fix this problem
- Removed the unnecessary `1px` which caused a scrollbar to appear on the home page
- Ensured consistent spacing throughout the UI
- Eliminated the theme toggle in the mobile navigation popover
  - The theme toggle is already present in the mobile header, so duplicating it was unnecessary

These changes aim to enhance the overall user experience and create a more consistent and streamlined UI. Take your time to review the changes. I'm totally up for any feedback or suggestions you might have.