### PR TITLE
added name of variable that was improperly accessed to error message

### DIFF
--- a/.changeset/twelve-bats-relate.md
+++ b/.changeset/twelve-bats-relate.md
@@ -1,0 +1,5 @@
+---
+"@t3-oss/env-core": minor
+---
+
+change default `onInvalidAccess` handler to log variable name in dev

--- a/docs/src/app/docs/customization/page.mdx
+++ b/docs/src/app/docs/customization/page.mdx
@@ -37,9 +37,15 @@ export const env = createEnv({
   },
   // Called when server variables are accessed on the client.
   onInvalidAccess: (variable: string) => {
-    throw new Error(
-      "❌ Attempted to access a server-side environment variable on the client"
-    );
+    if (process.env.NODE_ENV === "development") {
+      throw new Error(
+        `❌ Attempted to access a server-side environment variable '${variable}' on the client`
+      );
+    } else {
+      throw new Error(
+        `❌ Attempted to access a server-side environment variable on the client`
+      );
+    }
   },
 });
 ```

--- a/docs/src/app/docs/introduction/page.mdx
+++ b/docs/src/app/docs/introduction/page.mdx
@@ -49,7 +49,7 @@ By having an object you import and use throughout the application, you can use b
 
 By default, some frameworks (e.g. Next.js) treeshake away unused environment variables unless you explicitly access them on the `process.env` object. This means that the above implementation would fail even if you export and use the `envVariables` object in your application, as no environment will be included in the bundle for some environments / runtimes.
 
-Another pitfall is client side validation. Importing `envVariables` on the client will throw an error as the server side environment variables `DATABASE_URL` & `CUSTOM_STUFF` is not defined on the client. This library solves this issue by using a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) based implementation combined with Zod's `safeParse` method instead of `parse`.
+Another pitfall is client side validation. Importing `envVariables` on the client will throw an error as the server side environment variables `DATABASE_URL` & `CUSTOM_STUFF` is not defined on the client. This library solves this issue by using a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) based implementation combined with Zod's `safeParse` method instead of `parse`. If `NODE_ENV === 'development`, the error message will include the name of the variable that was accessed incorrectly.
 
 <Callout type="info">
 

--- a/docs/src/app/docs/introduction/page.mdx
+++ b/docs/src/app/docs/introduction/page.mdx
@@ -49,7 +49,7 @@ By having an object you import and use throughout the application, you can use b
 
 By default, some frameworks (e.g. Next.js) treeshake away unused environment variables unless you explicitly access them on the `process.env` object. This means that the above implementation would fail even if you export and use the `envVariables` object in your application, as no environment will be included in the bundle for some environments / runtimes.
 
-Another pitfall is client side validation. Importing `envVariables` on the client will throw an error as the server side environment variables `DATABASE_URL` & `CUSTOM_STUFF` is not defined on the client. This library solves this issue by using a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) based implementation combined with Zod's `safeParse` method instead of `parse`. If `NODE_ENV === 'development`, the error message will include the name of the variable that was accessed incorrectly.
+Another pitfall is client side validation. Importing `envVariables` on the client will throw an error as the server side environment variables `DATABASE_URL` & `CUSTOM_STUFF` is not defined on the client. This library solves this issue by using a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) based implementation combined with Zod's `safeParse` method instead of `parse`.
 
 <Callout type="info">
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -187,9 +187,15 @@ export function createEnv<
   const onInvalidAccess =
     opts.onInvalidAccess ??
     ((variable: string) => {
-      throw new Error(
-        `❌ Attempted to access a server-side environment variable '${variable}' on the client`
-      );
+      if (process.env.NODE_ENV === "development") {
+        throw new Error(
+          `❌ Attempted to access a server-side environment variable '${variable}' on the client`
+        );
+      } else {
+        throw new Error(
+          `❌ Attempted to access a server-side environment variable on the client`
+        );
+      }
     });
 
   if (parsed.success === false) {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -186,9 +186,9 @@ export function createEnv<
 
   const onInvalidAccess =
     opts.onInvalidAccess ??
-    ((_variable: string) => {
+    ((variable: string) => {
       throw new Error(
-        "❌ Attempted to access a server-side environment variable on the client"
+        `❌ Attempted to access a server-side environment variable '${variable}' on the client`
       );
     });
 


### PR DESCRIPTION
Let me know if this is out of line, but it was tricky to find which variable was being accessed when i first converted to this library.