### PR TITLE
Docs: Add anchor # links to headings

### DIFF
--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -11,7 +11,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     // Allows customizing built-in components, e.g. to add styling.
     h1: ({children, ...props}) => (
       <h1 
-        className="scroll-m-20 font-cal text-4xl mt-10"
+        className="scroll-m-20 font-cal text-4xl mt-10 hover:underline"
         {...props}
       >
         <a href={"#" + slugify(children)}>{children}</a>
@@ -19,7 +19,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     h2: ({children, ...props}) => (
       <h2
-        className="mt-10 scroll-m-20 border-b pb-2 font-cal text-3xl first:mt-0"
+        className="mt-10 scroll-m-20 border-b pb-2 font-cal text-3xl first:mt-0 hover:underline"
         id={slugify(children)}
         {...props}
       >
@@ -29,7 +29,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     h3: ({children, ...props}) => (
       <h3 
-        className="mt-8 scroll-m-20 font-cal text-2xl"
+        className="mt-8 scroll-m-20 font-cal text-2xl hover:underline"
         id={slugify(children)} 
         {...props}
       >
@@ -37,7 +37,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       </h3>
     ),
     h4: ({children, ...props}) => (
-      <h4 className="mt-6 -mb-4 scroll-m-20 font-cal text-2xl"
+      <h4 className="mt-6 -mb-4 scroll-m-20 font-cal text-2xl hover:underline"
         id={slugify(children)} 
         {...props}
       >

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -9,20 +9,40 @@ import { Codeblock } from "@/components/mdx/code-block";
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     // Allows customizing built-in components, e.g. to add styling.
-    h1: (props) => (
-      <h1 className="scroll-m-20 font-cal text-4xl mt-10" {...props} />
+    h1: ({children, ...props}) => (
+      <h1 
+        className="scroll-m-20 font-cal text-4xl mt-10"
+        {...props}
+      >
+        <a href={"#" + slugify(children)}>{children}</a>
+      </h1>
     ),
-    h2: (props) => (
+    h2: ({children, ...props}) => (
       <h2
         className="mt-10 scroll-m-20 border-b pb-2 font-cal text-3xl first:mt-0"
+        id={slugify(children)}
         {...props}
-      />
+      >
+        <a href={"#" + slugify(children)}>{children}</a>
+      </h2>
+
     ),
-    h3: (props) => (
-      <h3 className="mt-8 scroll-m-20 font-cal text-2xl" {...props} />
+    h3: ({children, ...props}) => (
+      <h3 
+        className="mt-8 scroll-m-20 font-cal text-2xl"
+        id={slugify(children)} 
+        {...props}
+      >
+        <a href={"#" + slugify(children)}>{children}</a>
+      </h3>
     ),
-    h4: (props) => (
-      <h4 className="mt-6 -mb-4 scroll-m-20 font-cal text-2xl" {...props} />
+    h4: ({children, ...props}) => (
+      <h4 className="mt-6 -mb-4 scroll-m-20 font-cal text-2xl"
+        id={slugify(children)} 
+        {...props}
+      >
+        <a href={"#" + slugify(children)}>{children}</a>
+      </h4>
     ),
     p: (props) => (
       <p className="leading-7 [&:not(:first-child)]:mt-6" {...props} />
@@ -62,4 +82,12 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     // Pass through all other components.
     ...components,
   };
+}
+
+function slugify(input: unknown) {
+  if (typeof input !== "string") {
+    console.error("slugify",input)
+    return ""
+  }
+  return input.replaceAll(" ", "-").toLowerCase().trim()
 }

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -86,7 +86,6 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
 
 function slugify(input: unknown) {
   if (typeof input !== "string") {
-    console.error("slugify",input)
     return ""
   }
   return input.replaceAll(" ", "-").toLowerCase().trim()

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -4,6 +4,7 @@ import type { MDXComponents } from "mdx/types";
 
 import { Callout } from "@/components/mdx/callout";
 import { Codeblock } from "@/components/mdx/code-block";
+import { Icons } from "@/components/icons";
 
 // This file is required to use MDX in `app` directory.
 export function useMDXComponents(components: MDXComponents): MDXComponents {
@@ -11,37 +12,46 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     // Allows customizing built-in components, e.g. to add styling.
     h1: ({children, ...props}) => (
       <h1 
-        className="scroll-m-20 font-cal text-4xl mt-10 hover:underline"
+        className="scroll-m-20 font-cal text-4xl mt-10"
         {...props}
       >
-        <a href={"#" + slugify(children)}>{children}</a>
+        {children}
       </h1>
     ),
     h2: ({children, ...props}) => (
       <h2
-        className="mt-10 scroll-m-20 border-b pb-2 font-cal text-3xl first:mt-0 hover:underline"
+        className="mt-10 scroll-m-20 border-b pb-2 font-cal text-3xl first:mt-0"
         id={slugify(children)}
         {...props}
       >
-        <a href={"#" + slugify(children)}>{children}</a>
+        <a className="group" href={"#" + slugify(children)}>
+          <span>{children}</span>
+          <Icons.link className="inline-flex ml-1 h-4 w-4 invisible group-hover:visible"/>
+        </a>
       </h2>
 
     ),
     h3: ({children, ...props}) => (
       <h3 
-        className="mt-8 scroll-m-20 font-cal text-2xl hover:underline"
+        className="mt-8 scroll-m-20 font-cal text-2xl"
         id={slugify(children)} 
         {...props}
       >
-        <a href={"#" + slugify(children)}>{children}</a>
+        <a className="group" href={"#" + slugify(children)}>
+          <span>{children}</span>
+          <Icons.link className="inline-flex ml-1 h-4 w-4 invisible group-hover:visible"/>
+        </a>
       </h3>
     ),
     h4: ({children, ...props}) => (
-      <h4 className="mt-6 -mb-4 scroll-m-20 font-cal text-2xl hover:underline"
+      <h4 className="mt-6 -mb-4 scroll-m-20 font-cal text-2xl"
         id={slugify(children)} 
         {...props}
       >
-        <a href={"#" + slugify(children)}>{children}</a>
+        <a className="group" href={"#" + slugify(children)}>
+          <span>{children}</span>
+          <Icons.link className="inline-flex ml-1 h-4 w-4 invisible group-hover:visible"/>
+        </a>
       </h4>
     ),
     p: (props) => (

--- a/docs/src/components/icons.tsx
+++ b/docs/src/components/icons.tsx
@@ -1,4 +1,5 @@
 import {
+  Link,
   LucideProps,
   Moon,
   SunMedium,
@@ -121,4 +122,5 @@ export const Icons = {
       </g>
     </svg>
   ),
+  link: Link,
 };


### PR DESCRIPTION
Links like https://env.t3.gg/docs/customization#skipping-validation will now scroll to the appropriate heading. Added anchor tags to each heading level, so you can easily share links to them . Heading ID's are generated by basic slugify function.

Added an underline on hover to let users know you can click on them. 

<img width="358" alt="image" src="https://github.com/t3-oss/t3-env/assets/43607012/4b1edf01-c9af-42e9-868d-4f82539076aa">

Closes my own issue, #115