### PR TITLE
fix: cjs __esModule field should not be evaluated as env variable

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -200,7 +200,7 @@ export function createEnv<
 
   const env = new Proxy(parsed.data, {
     get(target, prop) {
-      if (typeof prop !== "string") return undefined;
+      if (typeof prop !== "string" || prop === "__esModule") return undefined;
       if (
         !isServer &&
         opts.clientPrefix &&


### PR DESCRIPTION
fix #118 