### PR TITLE
docs: remove misleading boolean coercion example from recipes

### DIFF
--- a/docs/src/app/docs/recipes/page.mdx
+++ b/docs/src/app/docs/recipes/page.mdx
@@ -16,6 +16,8 @@ export const metadata = {
 
 Coercing booleans from strings is a common use case. Below are 2 examples of how to do this, but you can choose any coercian logic you want.
 
+Zod's default primitives coercion should not be used for booleans, since every string gets coerced to true.
+
 ```ts
 export const env = createEnv({
   server: {
@@ -30,10 +32,6 @@ export const env = createEnv({
       .refine((s) => s === "true" || s === "false")
       // transform to boolean
       .transform((s) => s === "true"),
-
-    // Alternatively, use Zod's default primitives coercion
-    // https://zod.dev/?id=coercion-for-primitives
-    ZOD_BOOLEAN_COERCION: z.coerce.boolean(),
   },
   // ...
 });


### PR DESCRIPTION
As discussed in #143 this removes a misleading / faulty example from the coercion recipes regarding booleans.
  
  
Related Zod Issue: https://github.com/colinhacks/zod/issues/1630
Maybe it could also be useful to add a reference to that issue in the docs ¯\\\_(ツ)\_/¯