### PR TITLE
Update next.js docs page to be more clear

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -19,13 +19,13 @@ pnpm add @t3-oss/env-nextjs zod
 
 <Callout>
 
-`@t3-oss/env-core` requires a minimum of `typescript@4.7.2`.
+`@t3-oss/env-nextjs` requires a minimum of `typescript@4.7.2`.
 
 </Callout>
 
 <Callout>
 
-`@t3-oss/env-core` is an ESM only package. Make sure that your tsconfig uses a module resolution that can read `package.json#exports` (`Bundler` is recommended).
+`@t3-oss/env-nextjs` is an ESM only package. Make sure that your tsconfig uses a module resolution that can read `package.json#exports` (`Bundler` is recommended).
 
 </Callout>
 


### PR DESCRIPTION
This page appears to have `<Callout />`s included that reference an older version of the docs, where the instructions for next.js were based on using `@t3-oss/env-core`.