### PR TITLE
docs: remove `runtimeEnv` option from examples for nuxt

### DIFF
--- a/docs/src/app/docs/nuxt/page.mdx
+++ b/docs/src/app/docs/nuxt/page.mdx
@@ -20,7 +20,7 @@ pnpm add @t3-oss/env-nuxt zod
 
 <Callout>
 
-`@t3-oss/env-core` requires a minimum of `typescript@4.7.2`.
+`@t3-oss/env-core` requires a minimum of `typescript@5`.
 
 </Callout>
 
@@ -62,7 +62,6 @@ export const env = createEnv({
     DATABASE_URL: z.string().url(),
     OPEN_AI_API_KEY: z.string().min(1),
   },
-  runtimeEnv: process.env,
 });
 ```
 
@@ -74,7 +73,6 @@ export const env = createEnv({
   client: {
     PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
   },
-  runtimeEnv: process.env,
 });
 ```
 


### PR DESCRIPTION
- This option `runtimeEnv` is omitted because it's set to `process.env` by default for nuxt.

- This package now requires typescript >=5