### PR TITLE
docs: use fileURLToPath to get correct file path on windows

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -102,8 +102,9 @@ export const env = createEnv({
 We recommend you importing your newly created file in your `next.config.js`. This will make sure your environment variables are validated at build time which will save you a lot of time and headaches down the road. You can use [unjs/jiti](https://github.com/unjs/jiti) to import TypeScript files in your `next.config.js`:
 
 ```js title="next.config.js" {5}
+import { fileURLToPath } from "node:url";
 import createJiti from "jiti";
-const jiti = createJiti(new URL(import.meta.url).pathname);
+const jiti = createJiti(fileURLToPath(import.meta.url));
 
 // Import env here to validate during build. Using jiti we can import .ts files :)
 jiti("./app/env");


### PR DESCRIPTION
According to https://github.com/nodejs/node/issues/37845, `new URL(import.meta.url).pathname` can not get the correct file path on Windows.