### PR TITLE
refactor: remove dependency on z.object

### DIFF
--- a/packages/core/test/smoke.test.ts
+++ b/packages/core/test/smoke.test.ts
@@ -231,7 +231,7 @@ describe("errors when validation fails", () => {
           FOO_BAR: "foo",
         },
         onValidationError: (err) => {
-          const barError = err.flatten().fieldErrors.BAR?.[0] as string;
+          const barError = err.BAR?.issues?.[0]?.message as string;
           throw new Error(`Invalid variable BAR: ${barError}`);
         },
       }),


### PR DESCRIPTION
refactor: remove dependency on z.object

Summary:
A step towards addressing #6. This PR removes the `z.object` internal wrapper. There's a breaking change on the `onValidationError` function, but it should be minor.

Test Plan:
```
bun run build
bun run test
```