### PR TITLE
fix: identify Deno as server (#154)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,7 +228,8 @@ export function createEnv<
   const client = z.object(_client);
   const server = z.object(_server);
   const shared = z.object(_shared);
-  const isServer = opts.isServer ?? typeof window === "undefined";
+  const isServer =
+    opts.isServer ?? (typeof window === "undefined" || "Deno" in window);
 
   const allClient = client.merge(shared);
   const allServer = server.merge(shared).merge(client);


### PR DESCRIPTION
@juliusmarminge We hit the faulty server detection explained in #154 when using t3-env on Netlify in a middleware in Next.js. Netlify uses Deno to bundle for edge, and this resulted in builds failing with "❌ Attempted to access a server-side environment variable on the client".

I think Netlify + Next.js middleware + t3-env qualifies as "_common_ setups widely used" as you put it in [your comment](https://github.com/t3-oss/t3-env/issues/154#issuecomment-2016830936)

We would appreciate out of the box support for this combo.
