### PR TITLE
Add explicit return types

### DIFF
--- a/.changeset/polite-fireants-drive.md
+++ b/.changeset/polite-fireants-drive.md
@@ -1,0 +1,7 @@
+---
+"@t3-oss/env-nextjs": patch
+"@t3-oss/env-core": patch
+"@t3-oss/env-nuxt": patch
+---
+
+refactor: add explicit return type to make lib more portable

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -1,5 +1,5 @@
 import type { ServerClientOptions, StrictOptions } from "@t3-oss/env-core";
-import { createEnv as createEnvCore } from "@t3-oss/env-core";
+import { type CreateEnv, createEnv as createEnvCore } from "@t3-oss/env-core";
 import type { ZodType } from "zod";
 
 const CLIENT_PREFIX = "NEXT_PUBLIC_" as const;
@@ -57,7 +57,9 @@ export function createEnv<
   > = NonNullable<unknown>,
   TShared extends Record<string, ZodType> = NonNullable<unknown>,
   const TExtends extends Array<Record<string, unknown>> = [],
->(opts: Options<TServer, TClient, TShared, TExtends>) {
+>(
+  opts: Options<TServer, TClient, TShared, TExtends>,
+): CreateEnv<TServer, TClient, TShared, TExtends> {
   const client = typeof opts.client === "object" ? opts.client : {};
   const server = typeof opts.server === "object" ? opts.server : {};
   const shared = opts.shared;

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -1,4 +1,4 @@
-import { createEnv as createEnvCore } from "@t3-oss/env-core";
+import { type CreateEnv, createEnv as createEnvCore } from "@t3-oss/env-core";
 import type { ServerClientOptions, StrictOptions } from "@t3-oss/env-core";
 import type { ZodType } from "zod";
 
@@ -18,10 +18,15 @@ type Options<
 
 export function createEnv<
   TServer extends Record<string, ZodType> = NonNullable<unknown>,
-  TClient extends Record<string, ZodType> = NonNullable<unknown>,
+  TClient extends Record<
+    `${ClientPrefix}${string}`,
+    ZodType
+  > = NonNullable<unknown>,
   TShared extends Record<string, ZodType> = NonNullable<unknown>,
   const TExtends extends Array<Record<string, unknown>> = [],
->(opts: Options<TServer, TClient, TShared, TExtends>) {
+>(
+  opts: Options<TServer, TClient, TShared, TExtends>,
+): CreateEnv<TServer, TClient, TShared, TExtends> {
   const client = typeof opts.client === "object" ? opts.client : {};
   const server = typeof opts.server === "object" ? opts.server : {};
   const shared = opts.shared;


### PR DESCRIPTION
This creates a `CreateEnv` utility type in `core/index.ts`. This type is then used to provide an explicit return type for the framework-specific `createEnv` calls. This would have prevented the Zod 3.23.0 declaration issue.