### PR TITLE
fix(docs): update TS version for peer dependency

### DIFF
--- a/docs/src/app/docs/core/page.mdx
+++ b/docs/src/app/docs/core/page.mdx
@@ -20,7 +20,7 @@ npm install @t3-oss/env-core zod
 
 <Callout>
 
-`@t3-oss/env-core` requires a minimum of `typescript@4.7.2`.
+`@t3-oss/env-core` requires a minimum of `typescript@5.0.0`.
 
 </Callout>
 

--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -19,7 +19,7 @@ pnpm add @t3-oss/env-nextjs zod
 
 <Callout>
 
-`@t3-oss/env-nextjs` requires a minimum of `typescript@4.7.2`.
+`@t3-oss/env-nextjs` requires a minimum of `typescript@5.0.0`.
 
 </Callout>
 


### PR DESCRIPTION
- updates the docs from TS peer dep v4 -> v5
- npm currently shows v5 as the minimum peer dep
```
pnpm view @t3-oss/env-nextjs peerDependencies
{ typescript: '>=5.0.0', zod: '^3.0.0' }
pnpm view @t3-oss/env-core peerDependencies
{ typescript: '>=5.0.0', zod: '^3.0.0' }
```