### PR TITLE
Update Next.js example code snippets

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -79,7 +79,13 @@ export const env = createEnv({
     DATABASE_URL: z.string().url(),
     OPEN_AI_API_KEY: z.string().min(1),
   },
-  runtimeEnv: process.env,
+  // If you're using Next.js < 13.4.4, you'll need to specify the runtimeEnv manually
+  // runtimeEnv: {
+  //   DATABASE_URL: process.env.DATABASE_URL,
+  //   OPEN_AI_API_KEY: process.env.OPEN_AI_API_KEY,
+  // },
+  // For Next.js >= 13.4.4, you can just reference process.env:
+  experimental__runtimeEnv: process.env
 });
 ```
 
@@ -89,9 +95,11 @@ import { z } from "zod";
 
 export const env = createEnv({
   client: {
-    PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
   },
-  runtimeEnv: process.env,
+  runtimeEnv: {
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+  },
 });
 ```
 


### PR DESCRIPTION
Updated the Next.js docs code snippets when separating environment variables between environments, since:
- The server had a wrong implementation of `runtimeEnv` that needs to be manually specified, using `experimental__runtimeEnv` instead if just referencing `process.env` (with comments)
- The client was missing the proper `NEXT_PUBLIC` prefix on the variable and the manual mapping of definition to `process.env` variable, since the client enforces these regardless of the Next.js version.