### PR TITLE
Add Cloudflare Pages to presets

### DIFF
--- a/docs/src/app/docs/customization/page.mdx
+++ b/docs/src/app/docs/customization/page.mdx
@@ -101,6 +101,7 @@ T3 Env ships the following presets out of the box, all importable from the `/pre
 - `render` - Render environment variables. See full list [here](https://docs.render.com/environment-variables#all-runtimes).
 - `railway` - Railway provided system environment variables. See full list [here](https://docs.railway.app/reference/variables#railway-provided-variables).
 - `fly.io` - Fly.io provided machine runtime environment variables. See full list [here](https://fly.io/docs/machines/runtime-environment/#environment-variables).
+- `cloudflarePages` - Cloudflare Pages system environment variables. See full list [here](https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables).
 
 <Callout type="info">
   Feel free to open a PR with more presets!

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -122,3 +122,18 @@ export const fly = () =>
     },
     runtimeEnv: process.env,
   });
+
+/**
+ * Cloudflare Pages Environment Variables
+ * @see https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables
+ */
+export const cloudflarePages = () =>
+  createEnv({
+    server: {
+      CF_PAGES: z.string().optional(),
+      CF_PAGES_BRANCH: z.string().optional(),
+      CF_PAGES_COMMIT_SHA: z.string().optional(),
+      CF_PAGES_URL: z.string().optional(),
+    },
+    runtimeEnv: process.env,
+  });


### PR DESCRIPTION
Cloudflare Pages automatically adds 4 environment variables, as defined in their [docs here](https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables).

* `CF_PAGES`
* `CF_PAGES_COMMIT_SHA`
* `CF_PAGES_BRANCH`
* `CF_PAGES_URL`

To match the other presets, I set all the values as `string().optional()`