### PR TITLE
feat: directly pass zod objects to server and client

### DIFF
--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -7,7 +7,7 @@ import { createEnv } from ".";
  */
 export const vercel = () =>
   createEnv({
-    server: {
+    server: z.object({
       VERCEL: z.string().optional(),
       VERCEL_ENV: z.enum(["development", "preview", "production"]).optional(),
       VERCEL_URL: z.string().optional(),
@@ -26,7 +26,7 @@ export const vercel = () =>
       VERCEL_GIT_COMMIT_AUTHOR_NAME: z.string().optional(),
       VERCEL_GIT_PREVIOUS_SHA: z.string().optional(),
       VERCEL_GIT_PULL_REQUEST_ID: z.string().optional(),
-    },
+    }),
     runtimeEnv: process.env,
   });
 
@@ -35,10 +35,10 @@ export const vercel = () =>
  */
 export const uploadthing = () =>
   createEnv({
-    server: {
+    server: z.object({
       UPLOADTHING_SECRET: z.string(),
       UPLOADTHING_APP_ID: z.string().optional(),
-    },
+    }),
     runtimeEnv: process.env,
   });
 
@@ -48,7 +48,7 @@ export const uploadthing = () =>
  */
 export const render = () =>
   createEnv({
-    server: {
+    server: z.object({
       IS_PULL_REQUEST: z.string().optional(),
       RENDER_DISCOVERY_SERVICE: z.string().optional(),
       RENDER_EXTERNAL_HOSTNAME: z.string().optional(),
@@ -63,7 +63,7 @@ export const render = () =>
         .enum(["web", "pserv", "cron", "worker", "static"])
         .optional(),
       RENDER: z.string().optional(),
-    },
+    }),
     runtimeEnv: process.env,
   });
 
@@ -73,7 +73,7 @@ export const render = () =>
  */
 export const railway = () =>
   createEnv({
-    server: {
+    server: z.object({
       RAILWAY_PUBLIC_DOMAIN: z.string().optional(),
       RAILWAY_PRIVATE_DOMAIN: z.string().optional(),
       RAILWAY_TCP_PROXY_DOMAIN: z.string().optional(),
@@ -97,7 +97,7 @@ export const railway = () =>
       RAILWAY_GIT_REPO_NAME: z.string().optional(),
       RAILWAY_GIT_REPO_OWNER: z.string().optional(),
       RAILWAY_GIT_COMMIT_MESSAGE: z.string().optional(),
-    },
+    }),
     runtimeEnv: process.env,
   });
 
@@ -107,7 +107,7 @@ export const railway = () =>
  */
 export const fly = () =>
   createEnv({
-    server: {
+    server: z.object({
       FLY_APP_NAME: z.string().optional(),
       FLY_MACHINE_ID: z.string().optional(),
       FLY_ALLOC_ID: z.string().optional(),
@@ -119,6 +119,6 @@ export const fly = () =>
       FLY_PROCESS_GROUP: z.string().optional(),
       FLY_VM_MEMORY_MB: z.string().optional(),
       PRIMARY_REGION: z.string().optional(),
-    },
+    }),
     runtimeEnv: process.env,
   });

--- a/packages/core/test/smoke.test.ts
+++ b/packages/core/test/smoke.test.ts
@@ -17,12 +17,12 @@ test("server vars should not be prefixed", () => {
   ignoreErrors(() => {
     createEnv({
       clientPrefix: "FOO_",
-      server: {
-        // @ts-expect-error - server should not have FOO_ prefix
+      // @ts-expect-error - server should not have FOO_ prefix
+      server: z.object({
         FOO_BAR: z.string(),
         BAR: z.string(),
-      },
-      client: {},
+      }),
+      client: z.object({}),
       runtimeEnv: {},
     });
   });
@@ -32,12 +32,12 @@ test("client vars should be correctly prefixed", () => {
   ignoreErrors(() => {
     createEnv({
       clientPrefix: "FOO_",
-      server: {},
-      client: {
+      server: z.object({}),
+      // @ts-expect-error - no FOO_ prefix
+      client: z.object({
         FOO_BAR: z.string(),
-        // @ts-expect-error - no FOO_ prefix
         BAR: z.string(),
-      },
+      }),
       runtimeEnv: {},
     });
   });
@@ -46,36 +46,36 @@ test("client vars should be correctly prefixed", () => {
 test("runtimeEnvStrict enforces all keys", () => {
   createEnv({
     clientPrefix: "FOO_",
-    server: {},
-    client: {},
+    server: z.object({}),
+    client: z.object({}),
     runtimeEnvStrict: {},
   });
 
   createEnv({
     clientPrefix: "FOO_",
-    server: {},
-    client: { FOO_BAR: z.string() },
+    server: z.object({}),
+    client: z.object({ FOO_BAR: z.string() }),
     runtimeEnvStrict: { FOO_BAR: "foo" },
   });
 
   createEnv({
     clientPrefix: "FOO_",
-    server: { BAR: z.string() },
-    client: {},
+    server: z.object({ BAR: z.string() }),
+    client: z.object({}),
     runtimeEnvStrict: { BAR: "foo" },
   });
 
   createEnv({
     clientPrefix: "FOO_",
-    server: { BAR: z.string() },
-    client: { FOO_BAR: z.string() },
+    server: z.object({ BAR: z.string() }),
+    client: z.object({ FOO_BAR: z.string() }),
     runtimeEnvStrict: { BAR: "foo", FOO_BAR: "foo" },
   });
 
   createEnv({
     clientPrefix: "FOO_",
-    server: {},
-    client: { FOO_BAR: z.string() },
+    server: z.object({}),
+    client: z.object({ FOO_BAR: z.string() }),
     runtimeEnvStrict: {
       FOO_BAR: "foo",
       // @ts-expect-error - FOO_BAZ is extraneous
@@ -86,8 +86,8 @@ test("runtimeEnvStrict enforces all keys", () => {
   ignoreErrors(() => {
     createEnv({
       clientPrefix: "FOO_",
-      server: { BAR: z.string() },
-      client: { FOO_BAR: z.string() },
+      server: z.object({ BAR: z.string() }),
+      client: z.object({ FOO_BAR: z.string() }),
       // @ts-expect-error - BAR is missing
       runtimeEnvStrict: {
         FOO_BAR: "foo",
@@ -100,8 +100,8 @@ describe("return type is correctly inferred", () => {
   test("simple", () => {
     const env = createEnv({
       clientPrefix: "FOO_",
-      server: { BAR: z.string() },
-      client: { FOO_BAR: z.string() },
+      server: z.object({ BAR: z.string() }),
+      client: z.object({ FOO_BAR: z.string() }),
       runtimeEnvStrict: {
         BAR: "bar",
         FOO_BAR: "foo",
@@ -124,8 +124,8 @@ describe("return type is correctly inferred", () => {
   test("with transforms", () => {
     const env = createEnv({
       clientPrefix: "FOO_",
-      server: { BAR: z.string().transform(Number) },
-      client: { FOO_BAR: z.string() },
+      server: z.object({ BAR: z.string().transform(Number) }),
+      client: z.object({ FOO_BAR: z.string() }),
       runtimeEnvStrict: {
         BAR: "123",
         FOO_BAR: "foo",
@@ -148,8 +148,8 @@ describe("return type is correctly inferred", () => {
   test("without client vars", () => {
     const env = createEnv({
       clientPrefix: "FOO_",
-      server: { BAR: z.string() },
-      client: {},
+      server: z.object({ BAR: z.string() }),
+      client: z.object({}),
       runtimeEnvStrict: {
         BAR: "bar",
       },
@@ -170,11 +170,11 @@ describe("return type is correctly inferred", () => {
 test("can pass number and booleans", () => {
   const env = createEnv({
     clientPrefix: "FOO_",
-    server: {
+    server: z.object({
       PORT: z.number(),
       IS_DEV: z.boolean(),
-    },
-    client: {},
+    }),
+    client: z.object({}),
     runtimeEnvStrict: {
       PORT: 123,
       IS_DEV: true,
@@ -199,8 +199,8 @@ describe("errors when validation fails", () => {
     expect(() =>
       createEnv({
         clientPrefix: "FOO_",
-        server: { BAR: z.string() },
-        client: { FOO_BAR: z.string() },
+        server: z.object({ BAR: z.string() }),
+        client: z.object({ FOO_BAR: z.string() }),
         runtimeEnv: {},
       }),
     ).toThrow("Invalid environment variables");
@@ -210,8 +210,10 @@ describe("errors when validation fails", () => {
     expect(() =>
       createEnv({
         clientPrefix: "FOO_",
-        server: { BAR: z.string().transform(Number).pipe(z.number()) },
-        client: { FOO_BAR: z.string() },
+        server: z.object({
+          BAR: z.string().transform(Number).pipe(z.number()),
+        }),
+        client: z.object({ FOO_BAR: z.string() }),
         runtimeEnv: {
           BAR: "123abc",
           FOO_BAR: "foo",
@@ -224,8 +226,10 @@ describe("errors when validation fails", () => {
     expect(() =>
       createEnv({
         clientPrefix: "FOO_",
-        server: { BAR: z.string().transform(Number).pipe(z.number()) },
-        client: { FOO_BAR: z.string() },
+        server: z.object({
+          BAR: z.string().transform(Number).pipe(z.number()),
+        }),
+        client: z.object({ FOO_BAR: z.string() }),
         runtimeEnv: {
           BAR: "123abc",
           FOO_BAR: "foo",
@@ -243,8 +247,8 @@ describe("errors when server var is accessed on client", () => {
   test("with default handler", () => {
     const env = createEnv({
       clientPrefix: "FOO_",
-      server: { BAR: z.string() },
-      client: { FOO_BAR: z.string() },
+      server: z.object({ BAR: z.string() }),
+      client: z.object({ FOO_BAR: z.string() }),
       runtimeEnvStrict: {
         BAR: "bar",
         FOO_BAR: "foo",
@@ -260,8 +264,8 @@ describe("errors when server var is accessed on client", () => {
   test("with custom handler", () => {
     const env = createEnv({
       clientPrefix: "FOO_",
-      server: { BAR: z.string() },
-      client: { FOO_BAR: z.string() },
+      server: z.object({ BAR: z.string() }),
+      client: z.object({ FOO_BAR: z.string() }),
       runtimeEnvStrict: {
         BAR: "bar",
         FOO_BAR: "foo",
@@ -280,9 +284,9 @@ describe("client/server only mode", () => {
   test("client only", () => {
     const env = createEnv({
       clientPrefix: "FOO_",
-      client: {
+      client: z.object({
         FOO_BAR: z.string(),
-      },
+      }),
       runtimeEnv: { FOO_BAR: "foo" },
     });
 
@@ -292,9 +296,9 @@ describe("client/server only mode", () => {
 
   test("server only", () => {
     const env = createEnv({
-      server: {
+      server: z.object({
         BAR: z.string(),
-      },
+      }),
       runtimeEnv: { BAR: "bar" },
     });
 
@@ -308,7 +312,7 @@ describe("client/server only mode", () => {
         // @ts-expect-error - incomplete client config - client not present
         {
           clientPrefix: "FOO_",
-          server: {},
+          server: z.object({}),
           runtimeEnv: {},
         },
       );
@@ -319,8 +323,8 @@ describe("client/server only mode", () => {
     ignoreErrors(() => {
       // @ts-expect-error - incomplete client config - clientPrefix not present
       createEnv({
-        client: {},
-        server: {},
+        client: z.object({}),
+        server: z.object({}),
         runtimeEnv: {},
       });
     });
@@ -336,12 +340,12 @@ describe("shared can be accessed on both server and client", () => {
 
   function lazyCreateEnv() {
     return createEnv({
-      shared: {
+      shared: z.object({
         NODE_ENV: z.enum(["development", "production", "test"]),
-      },
+      }),
       clientPrefix: "FOO_",
-      server: { BAR: z.string() },
-      client: { FOO_BAR: z.string() },
+      server: z.object({ BAR: z.string() }),
+      client: z.object({ FOO_BAR: z.string() }),
       runtimeEnv: process.env,
     });
   }
@@ -389,7 +393,7 @@ describe("shared can be accessed on both server and client", () => {
 
 test("envs are readonly", () => {
   const env = createEnv({
-    server: { BAR: z.string() },
+    server: z.object({ BAR: z.string() }),
     runtimeEnv: { BAR: "bar" },
   });
 
@@ -421,20 +425,20 @@ describe("extending presets", () => {
 
     function lazyCreateEnv() {
       const preset = createEnv({
-        server: {
+        server: z.object({
           PRESET_ENV: z.string(),
-        },
+        }),
         runtimeEnv: processEnv,
       });
 
       return createEnv({
-        server: {
+        server: z.object({
           SERVER_ENV: z.string(),
-        },
+        }),
         clientPrefix: "CLIENT_",
-        client: {
+        client: z.object({
           CLIENT_ENV: z.string(),
-        },
+        }),
         extends: [preset],
         runtimeEnv: processEnv,
       });
@@ -465,23 +469,23 @@ describe("extending presets", () => {
 
     function lazyCreateEnv() {
       const preset = createEnv({
-        server: {
+        server: z.object({
           PRESET_ENV: z.enum(["preset"]),
-        },
+        }),
         runtimeEnv: processEnv,
       });
 
       return createEnv({
-        server: {
+        server: z.object({
           SERVER_ENV: z.string(),
-        },
-        shared: {
+        }),
+        shared: z.object({
           SHARED_ENV: z.string(),
-        },
+        }),
         clientPrefix: "CLIENT_",
-        client: {
+        client: z.object({
           CLIENT_ENV: z.string(),
-        },
+        }),
         extends: [preset],
         runtimeEnv: processEnv,
       });
@@ -542,30 +546,30 @@ describe("extending presets", () => {
 
     function lazyCreateEnv() {
       const preset1 = createEnv({
-        server: {
+        server: z.object({
           PRESET_ENV1: z.enum(["preset"]),
-        },
+        }),
         runtimeEnv: processEnv,
       });
 
       const preset2 = createEnv({
-        server: {
+        server: z.object({
           PRESET_ENV2: z.number(),
-        },
+        }),
         runtimeEnv: processEnv,
       });
 
       return createEnv({
-        server: {
+        server: z.object({
           SERVER_ENV: z.string(),
-        },
-        shared: {
+        }),
+        shared: z.object({
           SHARED_ENV: z.string(),
-        },
+        }),
         clientPrefix: "CLIENT_",
-        client: {
+        client: z.object({
           CLIENT_ENV: z.string(),
-        },
+        }),
         extends: [preset1, preset2],
         runtimeEnv: processEnv,
       });

--- a/packages/nextjs/test/smoke.test.ts
+++ b/packages/nextjs/test/smoke.test.ts
@@ -16,12 +16,12 @@ function ignoreErrors(cb: () => void) {
 test("server vars should not be prefixed", () => {
   ignoreErrors(() => {
     createEnv({
-      server: {
-        // @ts-expect-error - server should not have NEXT_PUBLIC_ prefix
+      // @ts-expect-error - server should not have NEXT_PUBLIC_ prefix
+      server: z.object({
         NEXT_PUBLIC_BAR: z.string(),
         BAR: z.string(),
-      },
-      client: {},
+      }),
+      client: z.object({}),
       runtimeEnv: {
         BAR: "foo",
       },
@@ -32,12 +32,12 @@ test("server vars should not be prefixed", () => {
 test("client vars should be correctly prefixed", () => {
   ignoreErrors(() => {
     createEnv({
-      server: {},
-      client: {
+      server: z.object({}),
+      // @ts-expect-error - no NEXT_PUBLIC_ prefix
+      client: z.object({
         NEXT_PUBLIC_BAR: z.string(),
-        // @ts-expect-error - no NEXT_PUBLIC_ prefix
         BAR: z.string(),
-      },
+      }),
       runtimeEnv: {
         NEXT_PUBLIC_BAR: "foo",
       },
@@ -47,20 +47,20 @@ test("client vars should be correctly prefixed", () => {
 
 test("runtimeEnv enforces all keys", () => {
   createEnv({
-    server: {},
-    client: { NEXT_PUBLIC_BAR: z.string() },
+    server: z.object({}),
+    client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
     runtimeEnv: { NEXT_PUBLIC_BAR: "foo" },
   });
 
   createEnv({
-    server: { BAR: z.string() },
-    client: { NEXT_PUBLIC_BAR: z.string() },
+    server: z.object({ BAR: z.string() }),
+    client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
     runtimeEnv: { BAR: "foo", NEXT_PUBLIC_BAR: "foo" },
   });
 
   createEnv({
-    server: {},
-    client: { NEXT_PUBLIC_BAR: z.string() },
+    server: z.object({}),
+    client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
     runtimeEnv: {
       NEXT_PUBLIC_BAR: "foo",
       // @ts-expect-error - FOO_BAZ is extraneous
@@ -70,8 +70,8 @@ test("runtimeEnv enforces all keys", () => {
 
   ignoreErrors(() => {
     createEnv({
-      server: { BAR: z.string() },
-      client: { NEXT_PUBLIC_BAR: z.string() },
+      server: z.object({ BAR: z.string() }),
+      client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
       // @ts-expect-error - BAR is missing
       runtimeEnvStrict: {
         NEXT_PUBLIC_BAR: "foo",
@@ -83,14 +83,14 @@ test("runtimeEnv enforces all keys", () => {
 test("new experimental runtime option only requires client vars", () => {
   ignoreErrors(() => {
     createEnv({
-      server: { BAR: z.string() },
-      client: { NEXT_PUBLIC_BAR: z.string() },
+      server: z.object({ BAR: z.string() }),
+      client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
       // @ts-expect-error - NEXT_PUBLIC_BAR is missing
       experimental__runtimeEnv: {},
     });
     createEnv({
-      server: { BAR: z.string() },
-      client: { NEXT_PUBLIC_BAR: z.string() },
+      server: z.object({ BAR: z.string() }),
+      client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
       experimental__runtimeEnv: {
         // @ts-expect-error - BAR should not be specified
         BAR: "bar",
@@ -105,11 +105,11 @@ test("new experimental runtime option only requires client vars", () => {
   };
 
   const env = createEnv({
-    shared: {
+    shared: z.object({
       NODE_ENV: z.enum(["development", "production"]),
-    },
-    server: { BAR: z.string() },
-    client: { NEXT_PUBLIC_BAR: z.string() },
+    }),
+    server: z.object({ BAR: z.string() }),
+    client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
     experimental__runtimeEnv: {
       NODE_ENV: process.env.NODE_ENV,
       NEXT_PUBLIC_BAR: process.env.NEXT_PUBLIC_BAR,
@@ -134,8 +134,8 @@ test("new experimental runtime option only requires client vars", () => {
 describe("return type is correctly inferred", () => {
   test("simple", () => {
     const env = createEnv({
-      server: { BAR: z.string() },
-      client: { NEXT_PUBLIC_BAR: z.string() },
+      server: z.object({ BAR: z.string() }),
+      client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
       runtimeEnv: {
         BAR: "bar",
         NEXT_PUBLIC_BAR: "foo",
@@ -157,8 +157,8 @@ describe("return type is correctly inferred", () => {
 
   test("with transforms", () => {
     const env = createEnv({
-      server: { BAR: z.string().transform(Number) },
-      client: { NEXT_PUBLIC_BAR: z.string() },
+      server: z.object({ BAR: z.string().transform(Number) }),
+      client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
       runtimeEnv: {
         BAR: "123",
         NEXT_PUBLIC_BAR: "foo",
@@ -181,7 +181,7 @@ describe("return type is correctly inferred", () => {
 
 test("can specify only server", () => {
   const onlyServer = createEnv({
-    server: { BAR: z.string() },
+    server: z.object({ BAR: z.string() }),
     runtimeEnv: { BAR: "FOO" },
   });
 
@@ -196,7 +196,7 @@ test("can specify only server", () => {
 
 test("can specify only client", () => {
   const onlyClient = createEnv({
-    client: { NEXT_PUBLIC_BAR: z.string() },
+    client: z.object({ NEXT_PUBLIC_BAR: z.string() }),
     runtimeEnv: { NEXT_PUBLIC_BAR: "FOO" },
   });
 
@@ -218,19 +218,19 @@ describe("extending presets", () => {
 
     function lazyCreateEnv() {
       const preset = createEnv({
-        server: {
+        server: z.object({
           PRESET_ENV: z.string(),
-        },
+        }),
         experimental__runtimeEnv: processEnv,
       });
 
       return createEnv({
-        server: {
+        server: z.object({
           SERVER_ENV: z.string(),
-        },
-        client: {
+        }),
+        client: z.object({
           NEXT_PUBLIC_ENV: z.string(),
-        },
+        }),
         extends: [preset],
         runtimeEnv: processEnv,
       });
@@ -261,22 +261,22 @@ describe("extending presets", () => {
 
     function lazyCreateEnv() {
       const preset = createEnv({
-        server: {
+        server: z.object({
           PRESET_ENV: z.enum(["preset"]),
-        },
+        }),
         runtimeEnv: processEnv,
       });
 
       return createEnv({
-        server: {
+        server: z.object({
           SERVER_ENV: z.string(),
-        },
-        shared: {
+        }),
+        shared: z.object({
           SHARED_ENV: z.string(),
-        },
-        client: {
+        }),
+        client: z.object({
           NEXT_PUBLIC_ENV: z.string(),
-        },
+        }),
         extends: [preset],
         runtimeEnv: processEnv,
       });


### PR DESCRIPTION
fixes #169 

Improvements:
 - [x] Core package supports z.object
 - [x] Next package supports z.object
 - This PR only extends support for plain z.object types, meaning that `ZodObject`s with transforms / refines / catchs are not supported. The same goes for other specialized types (z.union, z.discriminatedUnion, z.record). 

Discussion:
 - I know that the main reason to use zod objects instead of the current implementation is to enable the power of refinements, unions and what not. 
 - The main issue is that applying these transformations to a zod object will convert its type from ZodObject to a ZodEffects, and ZodEffects don't have a merge method which is needed by the library to combine the validations required by client, server and shared schemas.
 - I'm already researching what can be done, but for now this PR handles a case where only plain `ZodObject`s are accepted