### PR TITLE
docs: update guide for schema validation on build for Next.js 15

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -107,7 +107,22 @@ export const env = createEnv({
 
 ### Validate schema on build (recommended)
 
-We recommend you importing your newly created file in your `next.config.js`. This will make sure your environment variables are validated at build time which will save you a lot of time and headaches down the road. You can use [unjs/jiti](https://github.com/unjs/jiti) to import TypeScript files in your `next.config.js`:
+We recommend you importing your newly created file in your `next.config.ts`. This will make sure your environment variables are validated at build time which will save you a lot of time and headaches down the road.
+
+```ts title="next.config.ts"
+import type { NextConfig } from "next";
+
+// Import env here to validate during build.
+import "./app/env";
+
+const nextConfig: NextConfig = {
+  /** ... */
+};
+```
+
+<Callout type="info">
+
+If you’re using Next.js version 14 or below, you can use [unjs/jiti](https://github.com/unjs/jiti) to import TypeScript files in your `next.config.js`:
 
 ```js title="next.config.js" {6}
 import { fileURLToPath } from "node:url";
@@ -122,6 +137,8 @@ export default {
   /** ... */
 };
 ```
+
+</Callout>
 
 ### Use your schema
 


### PR DESCRIPTION
Since now that Next.js 15 supports TypeScript for `next.config.ts`, we no longer need `jiti` for importing schema TS file. We will update the guide for Next.js 15, while still keeping the old guide for Next.js 14 or below.

fix #281