### PR TITLE
Persist default values when skipping validation

### DIFF
--- a/packages/core/test/smoke.test.ts
+++ b/packages/core/test/smoke.test.ts
@@ -620,3 +620,25 @@ describe("extending presets", () => {
     });
   });
 });
+
+describe("skipping validation", () => {
+  test("returns values when present", () => {
+    const env = createEnv({
+      server: { BAR: z.string().default("bar") },
+      runtimeEnv: { BAR: "foo" },
+      skipValidation: true,
+    });
+
+    expect(env).toMatchObject({ BAR: "foo" });
+  });
+
+  test("returns defaults when values missing", () => {
+    const env = createEnv({
+      server: { BAR: z.string().default("bar") },
+      runtimeEnv: {},
+      skipValidation: true,
+    });
+
+    expect(env).toMatchObject({ BAR: "bar" });
+  });
+});


### PR DESCRIPTION
Closing: https://github.com/t3-oss/t3-env/issues/266

When validation is skipped using `skipValidation: true`, the default values from zod schemas would still be taken into account.