### PR TITLE
fix: correct outdated Next.js docs and example

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -110,12 +110,11 @@ export const env = createEnv({
 We recommend you importing your newly created file in your `next.config.js`. This will make sure your environment variables are validated at build time which will save you a lot of time and headaches down the road. You can use [unjs/jiti](https://github.com/unjs/jiti) to import TypeScript files in your `next.config.js`:
 
 ```js title="next.config.js" {6}
-import { fileURLToPath } from "node:url";
-import createJiti from "jiti";
-const jiti = createJiti(fileURLToPath(import.meta.url));
+import { createJiti } from "jiti";
+const jiti = createJiti(new URL(import.meta.url).pathname);
 
 // Import env here to validate during build. Using jiti we can import .ts files :)
-jiti("./app/env");
+await jiti.import("./app/env");
 
 /** @type {import('next').NextConfig} */
 export default {

--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -1,8 +1,8 @@
-import createJiti from "jiti";
+import { createJiti } from "jiti";
 const jiti = createJiti(new URL(import.meta.url).pathname);
 
 // Import env here to validate during build. Using jiti we can import .ts files :)
-jiti("./app/env");
+await jiti.import("./app/env");
 
 /** @type {import('next').NextConfig} */
 export default {


### PR DESCRIPTION
jiti no longer uses the default export or the `jiti()` function. As such I have update the documentation to use the correct import: `import { createJiti } from "jiti"`, and the suggested replacement for the `jiti()` function: `await jiti.import()`. 

I also found that the documentation and example differed in the constuction of the path inside the `createJiti()` function. As such I have edited the documentation and the example to match each other to avoid confusion. I oped to use the syntax from the example: `const jiti = createJiti(new URL(import.meta.url).pathname)` as it doesn't require importing a function from node:url, which is currently the method used in the docs. 