### PR TITLE
Add version disclaimer to jiti docs

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -115,6 +115,7 @@ import createJiti from "jiti";
 const jiti = createJiti(fileURLToPath(import.meta.url));
 
 // Import env here to validate during build. Using jiti we can import .ts files :)
+// This syntax uses jiti v1.21.7, v2+ is not supported yet
 jiti("./app/env");
 
 /** @type {import('next').NextConfig} */

--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -114,8 +114,7 @@ import { fileURLToPath } from "node:url";
 import createJiti from "jiti";
 const jiti = createJiti(fileURLToPath(import.meta.url));
 
-// Import env here to validate during build. Using jiti we can import .ts files :)
-// This syntax uses jiti v1.21.7, v2+ is not supported yet
+// Import env here to validate during build. Using jiti@^1 we can import .ts files :)
 jiti("./app/env");
 
 /** @type {import('next').NextConfig} */
@@ -123,6 +122,8 @@ export default {
   /** ... */
 };
 ```
+
+We do not recommend using `next.config.ts` as it does not support loading ESM. 
 
 ### Use your schema
 


### PR DESCRIPTION
I ran into some odd issues when using jiti 2+, I think it may save a lot of heartache and needless GH issues to mention that it should use v1+