### PR TITLE
Add preset for Supabase

### DIFF
--- a/docs/src/app/docs/customization/page.mdx
+++ b/docs/src/app/docs/customization/page.mdx
@@ -98,6 +98,7 @@ T3 Env ships the following presets out of the box, all importable from the `/pre
 
 - `vercel` - Vercel environment variables. See full list [here](https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables).
 - `neonVercel` - Neon provided system environment variables when using the Vercel integration. See full list [here](https://neon.tech/docs/guides/vercel-native-integration#environment-variables-set-by-the-integration).
+- `supabaseVercel` - Supabase provided system environment variables when using the Vercel integration. See full list [here](https://vercel.com/marketplace/supabase).
 - `uploadthing` - All environment variables required to use [UploadThing](https://uploadthing.com/). More info [here](https://docs.uploadthing.com/getting-started/appdir#add-env-variables).
 - `render` - Render environment variables. See full list [here](https://docs.render.com/environment-variables#all-runtimes).
 - `railway` - Railway provided system environment variables. See full list [here](https://docs.railway.app/reference/variables#railway-provided-variables).

--- a/packages/core/src/presets-valibot.ts
+++ b/packages/core/src/presets-valibot.ts
@@ -1,4 +1,4 @@
-import { url, optional, picklist, pipe, string } from "valibot";
+import { optional, picklist, pipe, string, url } from "valibot";
 import type { StandardSchemaDictionary } from ".";
 import { createEnv } from ".";
 import type {
@@ -7,6 +7,7 @@ import type {
   NetlifyEnv,
   RailwayEnv,
   RenderEnv,
+  SupabaseVercelEnv,
   UploadThingEnv,
   UploadThingV6Env,
   VercelEnv,
@@ -67,6 +68,30 @@ export const neonVercel = () =>
       POSTGRES_URL_NO_SSL: optional(pipe(string(), url())),
       POSTGRES_PRISMA_URL: optional(pipe(string(), url())),
     } satisfies StandardSchemaDictionary.Matching<NeonVercelEnv>,
+    runtimeEnv: process.env,
+  });
+
+/**
+ * Supabase for Vercel Environment Variables
+ * @see https://vercel.com/marketplace/supabase
+ */
+export const supabaseVercel = () =>
+  createEnv({
+    server: {
+      POSTGRES_URL: pipe(string(), url()),
+      POSTGRES_PRISMA_URL: pipe(string(), url()),
+      POSTGRES_URL_NON_POOLING: pipe(string(), url()),
+      POSTGRES_USER: string(),
+      POSTGRES_HOST: string(),
+      POSTGRES_PASSWORD: string(),
+      POSTGRES_DATABASE: string(),
+      SUPABASE_SERVICE_ROLE_KEY: string(),
+      SUPABASE_ANON_KEY: string(),
+      SUPABASE_URL: pipe(string(), url()),
+      SUPABASE_JWT_SECRET: string(),
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: string(),
+      NEXT_PUBLIC_SUPABASE_URL: pipe(string(), url()),
+    } satisfies StandardSchemaDictionary.Matching<SupabaseVercelEnv>,
     runtimeEnv: process.env,
   });
 

--- a/packages/core/src/presets-zod.ts
+++ b/packages/core/src/presets-zod.ts
@@ -7,6 +7,7 @@ import type {
   NetlifyEnv,
   RailwayEnv,
   RenderEnv,
+  SupabaseVercelEnv,
   UploadThingEnv,
   UploadThingV6Env,
   VercelEnv,
@@ -67,6 +68,30 @@ export const neonVercel = () =>
       POSTGRES_URL_NO_SSL: z.string().url().optional(),
       POSTGRES_PRISMA_URL: z.string().url().optional(),
     } satisfies StandardSchemaDictionary.Matching<NeonVercelEnv>,
+    runtimeEnv: process.env,
+  });
+
+/**
+ * Supabase for Vercel Environment Variables
+ * @see https://vercel.com/marketplace/supabase
+ */
+export const supabaseVercel = () =>
+  createEnv({
+    server: {
+      POSTGRES_URL: z.string().url(),
+      POSTGRES_PRISMA_URL: z.string().url(),
+      POSTGRES_URL_NON_POOLING: z.string().url(),
+      POSTGRES_USER: z.string(),
+      POSTGRES_HOST: z.string(),
+      POSTGRES_PASSWORD: z.string(),
+      POSTGRES_DATABASE: z.string(),
+      SUPABASE_SERVICE_ROLE_KEY: z.string(),
+      SUPABASE_ANON_KEY: z.string(),
+      SUPABASE_URL: z.string().url(),
+      SUPABASE_JWT_SECRET: z.string(),
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
+      NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+    } satisfies StandardSchemaDictionary.Matching<SupabaseVercelEnv>,
     runtimeEnv: process.env,
   });
 

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -40,6 +40,22 @@ export interface NeonVercelEnv {
   POSTGRES_PRISMA_URL?: string;
 }
 
+export interface SupabaseVercelEnv {
+  POSTGRES_URL: string;
+  POSTGRES_PRISMA_URL: string;
+  POSTGRES_URL_NON_POOLING: string;
+  POSTGRES_USER: string;
+  POSTGRES_HOST: string;
+  POSTGRES_PASSWORD: string;
+  POSTGRES_DATABASE: string;
+  SUPABASE_SERVICE_ROLE_KEY: string;
+  SUPABASE_ANON_KEY: string;
+  SUPABASE_URL: string;
+  SUPABASE_JWT_SECRET: string;
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: string;
+  NEXT_PUBLIC_SUPABASE_URL: string;
+}
+
 export interface UploadThingV6Env {
   UPLOADTHING_TOKEN: string;
 }


### PR DESCRIPTION
Add preset for environment variables provided by the Supabase integration for Vercel. I'm not sure if any of the variables shouldn't be optional, but it's not written anywhere in the docs, so I think it's fine.