### PR TITLE
Next.js docs: Update syntax for jiti import due to deprecation

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -107,7 +107,7 @@ import createJiti from "jiti";
 const jiti = createJiti(fileURLToPath(import.meta.url));
 
 // Import env here to validate during build. Using jiti we can import .ts files :)
-jiti("./app/env");
+await jiti.import("./app/env");
 
 /** @type {import('next').NextConfig} */
 export default {


### PR DESCRIPTION
`jiti` has deprecated the syntax used in the docs for next.js here - I came across this on my own site while upgrading t3-env:

<img width="717" alt="image" src="https://github.com/user-attachments/assets/92c8e370-f15d-4ba7-8b8b-880d55a1be8d" />


Guidance from Jiti's repo: https://github.com/unjs/jiti/blob/c7cfeedbd2326976857bcd62726d73401d25dc03/lib/types.d.ts#L175-L176

```ts
  /** @deprecated Prefer `await jiti.import()` for better compatibility. */
  (id: string): any;
```

I'm using await syntax currently and it seems to be working