### PR TITLE
Fix confusing import in NextJS guide example

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -139,7 +139,7 @@ import createJiti from "jiti";
 const jiti = createJiti(fileURLToPath(import.meta.url));
 
 // Import env here to validate during build. Using jiti@^1 we can import .ts files :)
-jiti("./app/env");
+jiti("./src/env");
 
 /** @type {import('next').NextConfig} */
 export default {


### PR DESCRIPTION
Fix confusing import in NextJS guide example

`env.ts` is located in `src`, not in `app`.