### PR TITLE
fix: apply skipValidation to all presets when set on parent

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -235,8 +235,16 @@ export function createEnv<
   }
 
   const skip = !!opts.skipValidation;
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  if (skip) return runtimeEnv as any;
+  if (skip) {
+    if (opts.extends) {
+      for (const preset of opts.extends) {
+        preset.skipValidation = true;
+      }
+    }
+
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    return runtimeEnv as any;
+  }
 
   const _client = typeof opts.client === "object" ? opts.client : {};
   const _server = typeof opts.server === "object" ? opts.server : {};


### PR DESCRIPTION
Previously, presets ignored the parent’s `skipValidation` flag, requiring manual setup. This fix makes them inherit it automatically.

fixes #323.