### PR TITLE
Export StandardSchemaV1 from Next.js and Nuxt Packages

### DIFF
--- a/.changeset/clean-cats-poke.md
+++ b/.changeset/clean-cats-poke.md
@@ -1,0 +1,6 @@
+---
+"@t3-oss/env-nextjs": patch
+"@t3-oss/env-nuxt": patch
+---
+
+export StandardSchemaV1 and other @t3-oss/env-core types from @t3-oss/env-nextjs and @t3-oss/env-nuxt

--- a/docs/src/app/docs/customization/page.mdx
+++ b/docs/src/app/docs/customization/page.mdx
@@ -29,7 +29,8 @@ export const env = createEnv({
 ## Overriding the default error handler
 
 ```ts title="src/env.ts"
-import { createEnv } from "@t3-oss/env-core";
+import { createEnv, StandardSchemaV1 } from "@t3-oss/env-core";
+// Note: StandardSchemaV1 is also available in @t3-oss/env-nextjs and @t3-oss/env-nuxt packages
 
 export const env = createEnv({
   // ...

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -6,6 +6,13 @@ import type {
 } from "@t3-oss/env-core";
 import { createEnv as createEnvCore } from "@t3-oss/env-core";
 
+export type {
+  StandardSchemaV1,
+  StandardSchemaDictionary,
+  ErrorMessage,
+  Simplify,
+} from "@t3-oss/env-core";
+
 const CLIENT_PREFIX = "NEXT_PUBLIC_" as const;
 type ClientPrefix = typeof CLIENT_PREFIX;
 

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -6,6 +6,13 @@ import type {
 } from "@t3-oss/env-core";
 import { createEnv as createEnvCore } from "@t3-oss/env-core";
 
+export type {
+  StandardSchemaV1,
+  StandardSchemaDictionary,
+  ErrorMessage,
+  Simplify,
+} from "@t3-oss/env-core";
+
 const CLIENT_PREFIX = "NUXT_PUBLIC_" as const;
 type ClientPrefix = typeof CLIENT_PREFIX;
 


### PR DESCRIPTION
In the documentation for [Overriding the default error handler](https://env.t3.gg/docs/customization#overriding-the-default-error-handler), `StandardSchemaV1.Issue` is used, but `StandardSchemaV1` is not imported in the example and isn’t exported from `@t3-oss/env-nextjs` or `@t3-oss/env-nuxt`. This forces users to install `@t3-oss/env-core` or define `StandardSchemaV1` in their codebase when using Next.js or Nuxt, which isn’t ideal.

To fix this, I exported `StandardSchemaV1` from `@t3-oss/env-nextjs` and `@t3-oss/env-nuxt`, along with other types from `@t3-oss/env-core`, so these types are available to users of the Next.js or Nuxt versions.

**Note:** I’m not sure why `StandardSchemaDictionary`, `ErrorMessage`, and `Simplify` are exported from `@t3-oss/env-core` since they are not mentioned in the docs and users wouldn't need them. But anyway, I exported them from `@t3-oss/env-nextjs` and `@t3-oss/env-nuxt` so that if they are needed, users won’t have to install `@t3-oss/env-core`. I think they should not be exported from any package.
