### PR TITLE
Update env next import docs for Next v15

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -136,6 +136,21 @@ export default nextConfig
 
 We recommend you importing your newly created file in your `next.config.js`. This will make sure your environment variables are validated at build time which will save you a lot of time and headaches down the road. You can use [unjs/jiti](https://github.com/unjs/jiti) to import TypeScript files in your `next.config.js`:
 
+#### Version 15+
+```ts title="next.config.ts"
+// As of v15.0.0-canary.60, imports are allowed in next config
+import "./app/env";
+
+/** @type {import('next').NextConfig} */
+const nextConfig: NextConfig = {
+  /** ... */
+};
+
+export default nextConfig;
+```
+
+#### Version < NextJS 15 (`v15.0.0-canary.60`)
+
 ```js title="next.config.js" {6}
 import { fileURLToPath } from "node:url";
 import createJiti from "jiti";
@@ -149,8 +164,6 @@ export default {
   /** ... */
 };
 ```
-
-We do not recommend using `next.config.ts` as it does not support loading ESM. 
 
 ### Use your schema
 


### PR DESCRIPTION
Next 15 allows importing directly into next.config.ts

Seems to be working great, much easier to use.