### PR TITLE
fix: arktype not properly listed as an optional peer dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
         "zod": "^3.24.0 || ^4.0.0-beta.0",
       },
       "optionalPeers": [
+        "arktype",
         "typescript",
         "valibot",
         "zod",
@@ -134,11 +135,13 @@
         "zod": "3.24.3",
       },
       "peerDependencies": {
+        "arktype": "^2.1.0",
         "typescript": ">=5.0.0",
         "valibot": "^1.0.0-beta.7 || ^1.0.0",
         "zod": "^3.24.0 || ^4.0.0-beta.0",
       },
       "optionalPeers": [
+        "arktype",
         "typescript",
         "valibot",
         "zod",
@@ -158,11 +161,13 @@
         "zod": "3.24.3",
       },
       "peerDependencies": {
+        "arktype": "^2.1.0",
         "typescript": ">=5.0.0",
         "valibot": "^1.0.0-beta.7 || ^1.0.0",
         "zod": "^3.24.0 || ^4.0.0-beta.0",
       },
       "optionalPeers": [
+        "arktype",
         "typescript",
         "valibot",
         "zod",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,9 @@
     "typescript": {
       "optional": true
     },
+    "arktype": {
+      "optional": true
+    },
     "zod": {
       "optional": true
     },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -46,11 +46,15 @@
   },
   "peerDependencies": {
     "typescript": ">=5.0.0",
+    "arktype": "^2.1.0",
     "zod": "^3.24.0 || ^4.0.0-beta.0",
     "valibot": "^1.0.0-beta.7 || ^1.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
+      "optional": true
+    },
+    "arktype": {
       "optional": true
     },
     "zod": {

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -47,11 +47,15 @@
   },
   "peerDependencies": {
     "typescript": ">=5.0.0",
+    "arktype": "^2.1.0",
     "zod": "^3.24.0 || ^4.0.0-beta.0",
     "valibot": "^1.0.0-beta.7 || ^1.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
+      "optional": true
+    },
+    "arktype": {
       "optional": true
     },
     "zod": {


### PR DESCRIPTION
When it tried to install `@t3-oss/env-core` with pnpm i was surprised to see pnpm install `arktype` as a dependency. The core package should list `asktype` as an optional dependency since it work with any standard schema compatible library and let the user install his favorite validation library.