### PR TITLE
fix: `issue.message` missing from standard schema

### DIFF
--- a/packages/core/src/standard.ts
+++ b/packages/core/src/standard.ts
@@ -112,6 +112,7 @@ export function parseWithDictionary<TDict extends StandardSchemaDictionary>(
       issues.push(
         ...propResult.issues.map((issue) => ({
           ...issue,
+          message: issue.message,
           path: [key, ...(issue.path ?? [])],
         })),
       );


### PR DESCRIPTION
This fixes an issue where `issue.message` is missing with the default configuration, particularly with Arktype. The root cause is here:

https://github.com/t3-oss/t3-env/blob/e3b540457daa056696e1874833e02fc21354c437/packages/core/src/standard.ts#L111-L117

Specifically, the `...issue` spread does not copy `issue.message` because it is not an own key of `issue` when the Arktype schema being validated against is an atom (e.g., `type("string")`) rather than an object (e.g., `type({ /*...*/ })`).

Here is a minimal repro: https://stackblitz.com/edit/stackblitz-starters-j2p3sthd?file=index.ts&view=editor

The existing user-land workaround is to configure `createFinalSchema` to wrap the individual env vars into a single schema object.

```ts
export const env = createEnv({
	// ...
	createFinalSchema: (schema) => type(schema)
};
```
