### PR TITLE
Vite env shared

### DIFF
--- a/.changeset/thirty-eyes-tease.md
+++ b/.changeset/thirty-eyes-tease.md
@@ -1,0 +1,7 @@
+---
+"@t3-oss/env-core": patch
+"@t3-oss/env-nextjs": patch
+"@t3-oss/env-nuxt": patch
+---
+
+feat: change Vite `server` to `shared` variables

--- a/packages/core/src/presets-arktype.ts
+++ b/packages/core/src/presets-arktype.ts
@@ -268,7 +268,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
  */
 export const vite = (): Readonly<ViteEnv> =>
   createEnv({
-    server: {
+    shared: {
       BASE_URL: type("string"),
       MODE: type("string"),
       DEV: type("boolean"),

--- a/packages/core/src/presets-valibot.ts
+++ b/packages/core/src/presets-valibot.ts
@@ -268,7 +268,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
  */
 export const vite = (): Readonly<ViteEnv> =>
   createEnv({
-    server: {
+    shared: {
       BASE_URL: string(),
       MODE: string(),
       DEV: boolean(),

--- a/packages/core/src/presets-zod.ts
+++ b/packages/core/src/presets-zod.ts
@@ -268,7 +268,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
  */
 export const vite = (): Readonly<ViteEnv> =>
   createEnv({
-    server: {
+    shared: {
       BASE_URL: z.string(),
       MODE: z.string(),
       DEV: z.boolean(),


### PR DESCRIPTION
Changing Vite's `server` variables to `shared` variables. Vite seems exposes all the built-in `import.meta.env` constants o both client and server side (tested as well).

Thanks to @dylanhu7 for noticing this in the [original PR](https://github.com/t3-oss/t3-env/pull/353#issuecomment-2960075484) 🙏. 

With this change, all the built-in constants exposed by Vite shall available in both dev and client side without requiring any client side prefix.
