### PR TITLE
fix(docs): Update jiti example

### DIFF
--- a/docs/src/app/docs/nextjs/page.mdx
+++ b/docs/src/app/docs/nextjs/page.mdx
@@ -152,12 +152,12 @@ export default nextConfig;
 #### Version < NextJS 16
 
 ```js title="next.config.js" {6}
-import { fileURLToPath } from "node:url";
-import createJiti from "jiti";
-const jiti = createJiti(fileURLToPath(import.meta.url));
+import { createJiti } from 'jiti';
+
+const jiti = createJiti(import.meta.url);
 
 // Import env here to validate during build. Using jiti@^1 we can import .ts files :)
-jiti("./app/env");
+await jiti.import('./app/env');
 
 /** @type {import('next').NextConfig} */
 export default {


### PR DESCRIPTION
I attempted to set up the build-time validation for `@t3-oss/env-nextjs` using [`jiti`](https://github.com/unjs/jiti) due to the fact that I'm still on Next.js v14, and I ran into a few deprecation errors, so I figured the docs should be updated to show an example for the most recent version of `jiti`.

---

First, I'm seeing a `'default' is deprecated` message when using the default export from `'jiti'`:

<img width="591" height="337" alt="image" src="https://github.com/user-attachments/assets/1722beb2-a466-45a7-9f76-7f52423eb907" />

Which is easily fixed by switching to a non-default import:

```ts
import { createJiti } from 'jiti';
```

---

Next, looking at their examples, you don't even need to use `fileURLToPath` anymore, and can just pass `import.meta.url` directly to `createJiti`.

```ts
const jiti = createJiti(import.meta.url);
```

---

And finally, on the actual call with the created `jiti` instance, I'm getting another deprecation error:

```
'jiti' is deprecated. Prefer {@linkcode Jiti.importawait jiti.import()}for better compatibility.
```

<img width="772" height="312" alt="image" src="https://github.com/user-attachments/assets/99b2981e-07d4-4b7b-9d66-474b17406af6" />


The fix for this was just to use their async import approach:

```ts
await jiti.import('./app/env');
```

---

On a side note, I know Next.js v15 supports the `next.config.ts` file, is there a reason the docs say it only works for v16+?