### PR TITLE
fix(docs): suggest `z.stringbool()` for booleans

### DIFF
--- a/docs/src/app/docs/recipes/page.mdx
+++ b/docs/src/app/docs/recipes/page.mdx
@@ -17,7 +17,7 @@ Coercing booleans from strings is a common use case. Below are examples of how t
 
 <Callout type="warning">
 
-Zod's default primitives coercion should not be used for booleans, since every string gets coerced to true.
+Zod's default primitives coercion should not be used for booleans, since every string gets coerced to true. Alternatively, in Zod v4 you can use [`z.stringbool()`](https://zod.dev/api#stringbool) for coercion of strings to boolean.
 
 </Callout>
 


### PR DESCRIPTION
Updated warning about Zod's boolean coercion and introduced alternative method in Zod v4.