### PR TITLE
git push fork feat/sst-stage-env-support

### DIFF
--- a/.changeset/feat-sst-stage-env-support.md
+++ b/.changeset/feat-sst-stage-env-support.md
@@ -1,0 +1,48 @@
+---
+"@t3-oss/env-core": minor
+"@t3-oss/env-nextjs": minor
+---
+
+feat: add SST stage-specific env file support
+
+When using SST (Serverless Stack) with Next.js, environment variables are loaded
+from stage-specific files like `.env.dev`, `.env.staging`, `.env.prod` rather than
+the default `.env` that Next.js loads automatically. This caused t3-env validation
+to fail because `process.env` never contained those stage-scoped variables.
+
+This change adds two new utilities exported from `@t3-oss/env-core/sst` (and
+re-exported from `@t3-oss/env-nextjs/sst`):
+
+- **`loadSSTEnv(options?)`** — reads `SST_STAGE` from `process.env` and merges
+  the corresponding `.env.<stage>` file into the runtime env object.
+- **`loadEnvFile(filePath, cwd?)`** — generic helper that parses any dotenv-style
+  file and returns a key-value record; silently returns `{}` if the file is absent.
+
+Both functions are Node.js-only (use `node:fs`) and must not be imported in edge
+or browser contexts.
+
+A new `sst()` preset is also available in all three flavours
+(`presets-zod`, `presets-valibot`, `presets-arktype`) to validate and type the
+built-in SST env vars `SST_APP` and `SST_STAGE`.
+
+### Usage
+
+```ts
+// env.ts
+import { createEnv } from "@t3-oss/env-nextjs";
+import { loadSSTEnv } from "@t3-oss/env-nextjs/sst";
+import { sst } from "@t3-oss/env-nextjs/presets-zod";
+import { z } from "zod";
+
+export const env = createEnv({
+  server: {
+    DATABASE_URL: z.string().url(),
+    MY_SECRET: z.string(),
+  },
+  extends: [sst()],
+  runtimeEnv: {
+    ...process.env,
+    ...loadSSTEnv(), // merges .env.${SST_STAGE} automatically
+  },
+});
+```

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@t3-oss/env-root",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,78 +1,78 @@
 {
-  "name": "@t3-oss/env-core",
-  "version": "0.13.10",
-  "type": "module",
-  "keywords": [
-    "create-t3-app",
-    "environment variables",
-    "zod"
-  ],
-  "author": "Julius Marminge",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/t3-oss/t3-env",
-    "directory": "packages/core"
-  },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    },
-    "./presets-arktype": {
-      "types": "./dist/presets-arktype.d.ts",
-      "default": "./dist/presets-arktype.js"
-    },
-    "./presets-zod": {
-      "types": "./dist/presets-zod.d.ts",
-      "default": "./dist/presets-zod.js"
-    },
-    "./presets-valibot": {
-      "types": "./dist/presets-valibot.d.ts",
-      "default": "./dist/presets-valibot.js"
-    },
-    "./sst": {
-      "types": "./dist/sst.d.ts",
-      "default": "./dist/sst.js"
-    }
-  },
-  "files": [
-    "dist",
-    "package.json",
-    "LICENSE",
-    "README.md"
-  ],
-  "scripts": {
-    "build": "tsdown src/index.ts src/presets-arktype.ts src/presets-zod.ts src/presets-valibot.ts src/sst.ts --dts --platform neutral --unbundle",
-    "clean": "rm -rf dist node_modules .turbo .cache",
-    "typecheck": "tsgo --noEmit"
-  },
-  "peerDependencies": {
-    "arktype": "^2.1.0",
-    "typescript": ">=5.0.0",
-    "valibot": "^1.0.0-beta.7 || ^1.0.0",
-    "zod": "^3.24.0 || ^4.0.0"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    },
-    "arktype": {
-      "optional": true
-    },
-    "zod": {
-      "optional": true
-    },
-    "valibot": {
-      "optional": true
-    }
-  },
-  "devDependencies": {
-    "@typescript/native-preview": "7.0.0-dev.20251125.1",
-    "arktype": "2.1.22",
-    "tsdown": "0.16.7",
-    "valibot": "1.2.0",
-    "zod": "4.1.5"
-  }
+	"name": "@t3-oss/env-core",
+	"version": "0.13.10",
+	"type": "module",
+	"keywords": [
+		"create-t3-app",
+		"environment variables",
+		"zod"
+	],
+	"author": "Julius Marminge",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/t3-oss/t3-env",
+		"directory": "packages/core"
+	},
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		},
+		"./presets-arktype": {
+			"types": "./dist/presets-arktype.d.ts",
+			"default": "./dist/presets-arktype.js"
+		},
+		"./presets-zod": {
+			"types": "./dist/presets-zod.d.ts",
+			"default": "./dist/presets-zod.js"
+		},
+		"./presets-valibot": {
+			"types": "./dist/presets-valibot.d.ts",
+			"default": "./dist/presets-valibot.js"
+		},
+		"./sst": {
+			"types": "./dist/sst.d.ts",
+			"default": "./dist/sst.js"
+		}
+	},
+	"files": [
+		"dist",
+		"package.json",
+		"LICENSE",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsdown src/index.ts src/presets-arktype.ts src/presets-zod.ts src/presets-valibot.ts src/sst.ts --dts --platform neutral --unbundle",
+		"clean": "rm -rf dist node_modules .turbo .cache",
+		"typecheck": "tsgo --noEmit"
+	},
+	"peerDependencies": {
+		"arktype": "^2.1.0",
+		"typescript": ">=5.0.0",
+		"valibot": "^1.0.0-beta.7 || ^1.0.0",
+		"zod": "^3.24.0 || ^4.0.0"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		},
+		"arktype": {
+			"optional": true
+		},
+		"zod": {
+			"optional": true
+		},
+		"valibot": {
+			"optional": true
+		}
+	},
+	"devDependencies": {
+		"@typescript/native-preview": "7.0.0-dev.20251125.1",
+		"arktype": "2.1.22",
+		"tsdown": "0.16.7",
+		"valibot": "1.2.0",
+		"zod": "4.1.5"
+	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,10 @@
     "./presets-valibot": {
       "types": "./dist/presets-valibot.d.ts",
       "default": "./dist/presets-valibot.js"
+    },
+    "./sst": {
+      "types": "./dist/sst.d.ts",
+      "default": "./dist/sst.js"
     }
   },
   "files": [
@@ -40,7 +44,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts src/presets-arktype.ts src/presets-zod.ts src/presets-valibot.ts --dts --platform neutral --unbundle",
+    "build": "tsdown src/index.ts src/presets-arktype.ts src/presets-zod.ts src/presets-valibot.ts src/sst.ts --dts --platform neutral --unbundle",
     "clean": "rm -rf dist node_modules .turbo .cache",
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/core/src/presets-arktype.ts
+++ b/packages/core/src/presets-arktype.ts
@@ -12,6 +12,7 @@ import type {
   NetlifyEnv,
   RailwayEnv,
   RenderEnv,
+  SSTEnv,
   SupabaseVercelEnv,
   UploadThingEnv,
   UploadThingV6Env,
@@ -255,6 +256,19 @@ export const coolify = (): Readonly<CoolifyEnv> =>
       SOURCE_COMMIT: type("string | undefined"),
       PORT: type("string | undefined"),
       HOST: type("string | undefined"),
+    },
+    runtimeEnv: process.env,
+  });
+
+/**
+ * SST (Serverless Stack) Environment Variables
+ * @see https://sst.dev/docs/reference/cli#stage
+ */
+export const sst = (): Readonly<SSTEnv> =>
+  createEnv({
+    server: {
+      SST_APP: type("string | undefined"),
+      SST_STAGE: type("string | undefined"),
     },
     runtimeEnv: process.env,
   });

--- a/packages/core/src/presets-valibot.ts
+++ b/packages/core/src/presets-valibot.ts
@@ -12,6 +12,7 @@ import type {
   NetlifyEnv,
   RailwayEnv,
   RenderEnv,
+  SSTEnv,
   SupabaseVercelEnv,
   UploadThingEnv,
   UploadThingV6Env,
@@ -255,6 +256,19 @@ export const coolify = (): Readonly<CoolifyEnv> =>
       SOURCE_COMMIT: optional(string()),
       PORT: optional(string()),
       HOST: optional(string()),
+    },
+    runtimeEnv: process.env,
+  });
+
+/**
+ * SST (Serverless Stack) Environment Variables
+ * @see https://sst.dev/docs/reference/cli#stage
+ */
+export const sst = (): Readonly<SSTEnv> =>
+  createEnv({
+    server: {
+      SST_APP: optional(string()),
+      SST_STAGE: optional(string()),
     },
     runtimeEnv: process.env,
   });

--- a/packages/core/src/presets-zod.ts
+++ b/packages/core/src/presets-zod.ts
@@ -12,6 +12,7 @@ import type {
   NetlifyEnv,
   RailwayEnv,
   RenderEnv,
+  SSTEnv,
   SupabaseVercelEnv,
   UploadThingEnv,
   UploadThingV6Env,
@@ -255,6 +256,19 @@ export const coolify = (): Readonly<CoolifyEnv> =>
       SOURCE_COMMIT: z.string().optional(),
       PORT: z.string().optional(),
       HOST: z.string().optional(),
+    },
+    runtimeEnv: process.env,
+  });
+
+/**
+ * SST (Serverless Stack) Environment Variables
+ * @see https://sst.dev/docs/reference/cli#stage
+ */
+export const sst = (): Readonly<SSTEnv> =>
+  createEnv({
+    server: {
+      SST_APP: z.string().optional(),
+      SST_STAGE: z.string().optional(),
     },
     runtimeEnv: process.env,
   });

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -167,3 +167,18 @@ export interface WxtEnv {
   EDGE?: boolean;
   OPERA?: boolean;
 }
+
+/**
+ * SST (Serverless Stack) Environment Variables
+ * @see https://sst.dev/docs/reference/cli#stage
+ */
+export interface SSTEnv {
+  /**
+   * The name of the SST app
+   */
+  SST_APP?: string;
+  /**
+   * The current SST stage (e.g. "dev", "staging", "prod")
+   */
+  SST_STAGE?: string;
+}

--- a/packages/core/src/sst.ts
+++ b/packages/core/src/sst.ts
@@ -1,0 +1,143 @@
+/**
+ * SST (Serverless Stack) utilities for t3-env.
+ *
+ * Provides helpers to load stage-specific `.env.[stage]` files so that
+ * environment variables defined by SST stages are available for validation.
+ *
+ * @see https://sst.dev/docs/reference/cli#stage
+ * @module
+ *
+ * @note This module uses `node:fs` and is intended for **Node.js server
+ * environments only**. Do not import it in edge runtime or browser code.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Parses dotenv-style file content into a key-value record.
+ * - Lines starting with `#` are treated as comments and skipped.
+ * - Values can be wrapped in single or double quotes (quotes are stripped).
+ * @internal
+ */
+function parseEnvContent(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const eqIndex = trimmed.indexOf("=");
+    if (eqIndex === -1) continue;
+
+    const key = trimmed.slice(0, eqIndex).trim();
+    let value = trimmed.slice(eqIndex + 1).trim();
+
+    // Strip surrounding single or double quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (key) result[key] = value;
+  }
+
+  return result;
+}
+
+/**
+ * Loads and parses environment variables from a dotenv-style file.
+ *
+ * Silently returns an empty object if the file does not exist or cannot be
+ * read, so it is safe to call even when the file may be absent.
+ *
+ * @param filePath - Path to the env file. Relative paths are resolved from
+ *   `cwd` (defaults to `process.cwd()`).
+ * @param cwd - Base directory used to resolve relative `filePath` values.
+ *   Defaults to `process.cwd()`.
+ * @returns Parsed key-value pairs from the env file, or `{}` on any error.
+ *
+ * @example
+ * ```ts
+ * import { createEnv } from "@t3-oss/env-nextjs";
+ * import { loadEnvFile } from "@t3-oss/env-core/sst";
+ *
+ * export const env = createEnv({
+ *   runtimeEnv: {
+ *     ...process.env,
+ *     ...loadEnvFile(".env.dev"),
+ *   },
+ *   server: { MY_SECRET: z.string() },
+ * });
+ * ```
+ */
+export function loadEnvFile(
+  filePath: string,
+  cwd: string = process.cwd(),
+): Record<string, string> {
+  try {
+    const fullPath = resolve(cwd, filePath);
+    const content = readFileSync(fullPath, "utf-8");
+    return parseEnvContent(content);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Loads environment variables from the SST stage-specific env file.
+ *
+ * Reads the current stage from the `SST_STAGE` environment variable (or a
+ * custom variable via `options.stageVar`) and loads the corresponding
+ * `.env.<stage>` file. Returns an empty object when `SST_STAGE` is not set
+ * or the file does not exist.
+ *
+ * @param options.stageVar - Name of the env var that holds the stage name.
+ *   Defaults to `"SST_STAGE"`.
+ * @param options.cwd - Directory to look for the env file. Defaults to
+ *   `process.cwd()`.
+ * @returns Parsed key-value pairs from the stage-specific env file.
+ *
+ * @example
+ * ```ts
+ * // env.ts
+ * import { createEnv } from "@t3-oss/env-nextjs";
+ * import { loadSSTEnv } from "@t3-oss/env-core/sst";
+ * import { z } from "zod";
+ *
+ * // SST sets SST_STAGE=dev, so this reads from .env.dev automatically.
+ * export const env = createEnv({
+ *   runtimeEnv: {
+ *     ...process.env,
+ *     ...loadSSTEnv(),
+ *   },
+ *   server: {
+ *     DATABASE_URL: z.string().url(),
+ *     MY_SECRET: z.string(),
+ *   },
+ * });
+ * ```
+ */
+export function loadSSTEnv(options?: {
+  /**
+   * The environment variable that holds the SST stage name.
+   * @default "SST_STAGE"
+   */
+  stageVar?: string;
+  /**
+   * Directory in which to look for the `.env.[stage]` file.
+   * @default process.cwd()
+   */
+  cwd?: string;
+}): Record<string, string> {
+  const stageVar = options?.stageVar ?? "SST_STAGE";
+  const cwd = options?.cwd ?? process.cwd();
+  const stage = process.env[stageVar];
+
+  if (!stage) return {};
+
+  return loadEnvFile(`.env.${stage}`, cwd);
+}

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -32,6 +32,10 @@
     "./presets-valibot": {
       "types": "./dist/presets-valibot.d.ts",
       "default": "./dist/presets-valibot.js"
+    },
+    "./sst": {
+      "types": "./dist/sst.d.ts",
+      "default": "./dist/sst.js"
     }
   },
   "files": [
@@ -41,7 +45,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts src/presets-arktype.ts src/presets-zod.ts src/presets-valibot.ts --dts --platform neutral --unbundle",
+    "build": "tsdown src/index.ts src/presets-arktype.ts src/presets-zod.ts src/presets-valibot.ts src/sst.ts --dts --platform neutral --unbundle",
     "clean": "rm -rf dist node_modules .turbo .cache",
     "typecheck": "tsgo --noEmit",
     "prepack": "bun ../../scripts/replace-workspace-protocol.ts"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,83 +1,83 @@
 {
-  "name": "@t3-oss/env-nextjs",
-  "version": "0.13.10",
-  "type": "module",
-  "keywords": [
-    "create-t3-app",
-    "environment variables",
-    "zod",
-    "nextjs"
-  ],
-  "author": "Julius Marminge",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/t3-oss/t3-env",
-    "directory": "packages/nextjs"
-  },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    },
-    "./presets-arktype": {
-      "types": "./dist/presets-arktype.d.ts",
-      "default": "./dist/presets-arktype.js"
-    },
-    "./presets-zod": {
-      "types": "./dist/presets-zod.d.ts",
-      "default": "./dist/presets-zod.js"
-    },
-    "./presets-valibot": {
-      "types": "./dist/presets-valibot.d.ts",
-      "default": "./dist/presets-valibot.js"
-    },
-    "./sst": {
-      "types": "./dist/sst.d.ts",
-      "default": "./dist/sst.js"
-    }
-  },
-  "files": [
-    "dist",
-    "package.json",
-    "LICENSE",
-    "README.md"
-  ],
-  "scripts": {
-    "build": "tsdown src/index.ts src/presets-arktype.ts src/presets-zod.ts src/presets-valibot.ts src/sst.ts --dts --platform neutral --unbundle",
-    "clean": "rm -rf dist node_modules .turbo .cache",
-    "typecheck": "tsgo --noEmit",
-    "prepack": "bun ../../scripts/replace-workspace-protocol.ts"
-  },
-  "dependencies": {
-    "@t3-oss/env-core": "workspace:*"
-  },
-  "peerDependencies": {
-    "arktype": "^2.1.0",
-    "typescript": ">=5.0.0",
-    "valibot": "^1.0.0-beta.7 || ^1.0.0",
-    "zod": "^3.24.0 || ^4.0.0"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    },
-    "arktype": {
-      "optional": true
-    },
-    "zod": {
-      "optional": true
-    },
-    "valibot": {
-      "optional": true
-    }
-  },
-  "devDependencies": {
-    "@typescript/native-preview": "7.0.0-dev.20251125.1",
-    "arktype": "2.1.22",
-    "tsdown": "0.16.7",
-    "valibot": "1.2.0",
-    "zod": "4.1.5"
-  }
+	"name": "@t3-oss/env-nextjs",
+	"version": "0.13.10",
+	"type": "module",
+	"keywords": [
+		"create-t3-app",
+		"environment variables",
+		"zod",
+		"nextjs"
+	],
+	"author": "Julius Marminge",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/t3-oss/t3-env",
+		"directory": "packages/nextjs"
+	},
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		},
+		"./presets-arktype": {
+			"types": "./dist/presets-arktype.d.ts",
+			"default": "./dist/presets-arktype.js"
+		},
+		"./presets-zod": {
+			"types": "./dist/presets-zod.d.ts",
+			"default": "./dist/presets-zod.js"
+		},
+		"./presets-valibot": {
+			"types": "./dist/presets-valibot.d.ts",
+			"default": "./dist/presets-valibot.js"
+		},
+		"./sst": {
+			"types": "./dist/sst.d.ts",
+			"default": "./dist/sst.js"
+		}
+	},
+	"files": [
+		"dist",
+		"package.json",
+		"LICENSE",
+		"README.md"
+	],
+	"scripts": {
+		"build": "tsdown src/index.ts src/presets-arktype.ts src/presets-zod.ts src/presets-valibot.ts src/sst.ts --dts --platform neutral --unbundle",
+		"clean": "rm -rf dist node_modules .turbo .cache",
+		"typecheck": "tsgo --noEmit",
+		"prepack": "bun ../../scripts/replace-workspace-protocol.ts"
+	},
+	"dependencies": {
+		"@t3-oss/env-core": "workspace:*"
+	},
+	"peerDependencies": {
+		"arktype": "^2.1.0",
+		"typescript": ">=5.0.0",
+		"valibot": "^1.0.0-beta.7 || ^1.0.0",
+		"zod": "^3.24.0 || ^4.0.0"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		},
+		"arktype": {
+			"optional": true
+		},
+		"zod": {
+			"optional": true
+		},
+		"valibot": {
+			"optional": true
+		}
+	},
+	"devDependencies": {
+		"@typescript/native-preview": "7.0.0-dev.20251125.1",
+		"arktype": "2.1.22",
+		"tsdown": "0.16.7",
+		"valibot": "1.2.0",
+		"zod": "4.1.5"
+	}
 }

--- a/packages/nextjs/src/sst.ts
+++ b/packages/nextjs/src/sst.ts
@@ -1,0 +1,11 @@
+/**
+ * SST (Serverless Stack) utilities re-exported from `@t3-oss/env-core/sst`
+ * for convenience when using the Next.js package.
+ *
+ * @see https://sst.dev/docs/reference/cli#stage
+ * @module
+ *
+ * @note This module uses `node:fs` and is intended for **Node.js server
+ * environments only**. Do not import it in edge runtime or browser code.
+ */
+export { loadEnvFile, loadSSTEnv } from "@t3-oss/env-core/sst";


### PR DESCRIPTION
## Problem

When using SST (Serverless Stack) with Next.js, environment variables are defined in stage-specific files like `.env.dev`, `.env.staging`, or `.env.prod`. Next.js does not auto-load these files, so `process.env` is missing those variables at validation time — causing t3-env to throw even when the variables are correctly defined.

## Solution

Adds two new utilities exported from `@t3-oss/env-core/sst` (re-exported from `@t3-oss/env-nextjs/sst`):

- `loadSSTEnv(options?)` — reads `SST_STAGE` from `process.env` and merges the corresponding `.env.<stage>` file
- `loadEnvFile(filePath, cwd?)` — generic helper that parses any dotenv-style file; silently returns `{}` if the file is absent

Both are Node.js-only (`node:fs`) and must not be used in edge/browser contexts.

Also adds a `sst()` preset to `presets-zod`, `presets-valibot`, and `presets-arktype` for validating the built-in SST variables `SST_APP` and `SST_STAGE`.

## Usage

```ts
import { createEnv } from "@t3-oss/env-nextjs";
import { loadSSTEnv } from "@t3-oss/env-nextjs/sst";
import { sst } from "@t3-oss/env-nextjs/presets-zod";
import { z } from "zod";

export const env = createEnv({
  server: {
    DATABASE_URL: z.string().url(),
  },
  extends: [sst()],
  runtimeEnv: {
    ...process.env,
    ...loadSSTEnv(), // automatically merges .env.${SST_STAGE}
  },
});