### PR TITLE
fix(core): include extended env vars when skipValidation is true

### DIFF
--- a/.changeset/fix-skip-validation-extended-env.md
+++ b/.changeset/fix-skip-validation-extended-env.md
@@ -1,0 +1,10 @@
+---
+"@t3-oss/env-core": patch
+---
+
+fix: include extended env vars when `skipValidation` is true
+
+Previously, calling `createEnv` with `skipValidation: true` returned only
+`runtimeEnv`, silently dropping any variables contributed by the `extends`
+array. Extended variables are now merged in (with `runtimeEnv` taking
+precedence), matching the behaviour of the normal validation path.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -323,6 +323,10 @@ export function createEnv<
     }
   }
 
+  const extendedObj = (opts.extends ?? []).reduce((acc, curr) => {
+    return Object.assign(acc, curr);
+  }, {});
+
   const skip = !!opts.skipValidation;
   if (skip) {
     if (opts.extends) {
@@ -332,7 +336,7 @@ export function createEnv<
     }
 
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-    return runtimeEnv as any;
+    return Object.assign(extendedObj, runtimeEnv) as any;
   }
 
   const _client = typeof opts.client === "object" ? opts.client : {};
@@ -386,9 +390,6 @@ export function createEnv<
     return prop === "__esModule" || prop === "$$typeof";
   };
 
-  const extendedObj = (opts.extends ?? []).reduce((acc, curr) => {
-    return Object.assign(acc, curr);
-  }, {});
   const fullObj = Object.assign(extendedObj, parsed.value);
 
   const env = new Proxy(fullObj, {

--- a/packages/core/test/smoke-zod4.test.ts
+++ b/packages/core/test/smoke-zod4.test.ts
@@ -787,6 +787,75 @@ test("overriding preset env var", () => {
   expect(env.PRESET_ENV).toBe(123);
 });
 
+describe("skipValidation with extends", () => {
+  test("includes extended env vars when skipValidation is true", () => {
+    const processEnv = {
+      PRESET_ENV: "preset",
+      MY_VAR: "myvar",
+    };
+
+    const preset = createEnv({
+      server: { PRESET_ENV: z.string() },
+      runtimeEnv: processEnv,
+    });
+
+    const env = createEnv({
+      server: { MY_VAR: z.string() },
+      extends: [preset],
+      runtimeEnv: processEnv,
+      skipValidation: true,
+    });
+
+    expect(env.MY_VAR).toBe("myvar");
+    expect(env.PRESET_ENV).toBe("preset");
+  });
+
+  test("runtimeEnv values take precedence over extended env vars when skipValidation is true", () => {
+    const preset = createEnv({
+      server: { SHARED_VAR: z.string() },
+      runtimeEnv: { SHARED_VAR: "from-preset" },
+    });
+
+    const env = createEnv({
+      server: { SHARED_VAR: z.string() },
+      extends: [preset],
+      runtimeEnv: { SHARED_VAR: "from-runtime" },
+      skipValidation: true,
+    });
+
+    expect(env.SHARED_VAR).toBe("from-runtime");
+  });
+
+  test("includes vars from multiple extended presets when skipValidation is true", () => {
+    const processEnv = {
+      PRESET_ENV1: "preset1",
+      PRESET_ENV2: "preset2",
+      MY_VAR: "myvar",
+    };
+
+    const preset1 = createEnv({
+      server: { PRESET_ENV1: z.string() },
+      runtimeEnv: processEnv,
+    });
+
+    const preset2 = createEnv({
+      server: { PRESET_ENV2: z.string() },
+      runtimeEnv: processEnv,
+    });
+
+    const env = createEnv({
+      server: { MY_VAR: z.string() },
+      extends: [preset1, preset2],
+      runtimeEnv: processEnv,
+      skipValidation: true,
+    });
+
+    expect(env.MY_VAR).toBe("myvar");
+    expect(env.PRESET_ENV1).toBe("preset1");
+    expect(env.PRESET_ENV2).toBe("preset2");
+  });
+});
+
 test("with built-in preset", () => {
   process.env.UPLOADTHING_TOKEN = "token";
   const env = createEnv({


### PR DESCRIPTION
 ## Problem

When `createEnv` is called with `skipValidation: true`, it returned `runtimeEnv` directly via an early return, silently dropping all variables contributed by the `extends` array. This meant that any preset env vars (e.g. from `uploadthing()` or a shared base env) were `undefined` at runtime whenever validation was skipped.

## Fix

Hoist `extendedObj` above the skip guard and return `Object.assign(extendedObj, runtimeEnv)` instead of bare `runtimeEnv`. This matches the merge order of the normal validation path, so `runtimeEnv` values continue to take precedence over preset values.

## Tests

Three regression tests added to `smoke-zod4.test.ts`: 

- extended env vars are accessible when `skipValidation: true`
- `runtimeEnv` values override extended preset values (precedence preserved)
- vars from multiple extended presets are all accessible