### PR TITLE
fix(presets): guard against ReferenceError when process is not defined

### DIFF
--- a/.changeset/fix-preset-browser-guard.md
+++ b/.changeset/fix-preset-browser-guard.md
@@ -1,0 +1,5 @@
+---
+"@t3-oss/env-core": patch
+---
+
+Server presets no longer crash with `ReferenceError: process is not defined` in browser environments such as Vite apps that do not polyfill `process`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -312,7 +312,10 @@ export function createEnv<
 >(
   opts: EnvOptions<TPrefix, TServer, TClient, TShared, TExtends, TFinalSchema>,
 ): CreateEnv<TFinalSchema, TExtends> {
-  const runtimeEnv = opts.runtimeEnvStrict ?? opts.runtimeEnv ?? process.env;
+  const runtimeEnv =
+    opts.runtimeEnvStrict ??
+    opts.runtimeEnv ??
+    (typeof process !== "undefined" ? process.env : {});
 
   const emptyStringAsUndefined = opts.emptyStringAsUndefined ?? false;
   if (emptyStringAsUndefined) {

--- a/packages/core/src/presets-arktype.ts
+++ b/packages/core/src/presets-arktype.ts
@@ -21,7 +21,7 @@ import type {
   WxtEnv,
 } from "./presets.ts";
 
-const serverRuntimeEnv: Record<string, string | undefined> =
+const serverEnv = (): Record<string, string | undefined> =>
   typeof process !== "undefined" ? process.env : {};
 
 /**
@@ -54,7 +54,7 @@ export const vercel = (): Readonly<VercelEnv> =>
       VERCEL_GIT_PREVIOUS_SHA: type("string | undefined"),
       VERCEL_GIT_PULL_REQUEST_ID: type("string | undefined"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -80,7 +80,7 @@ export const neonVercel = (): Readonly<NeonVercelEnv> =>
       POSTGRES_URL_NO_SSL: type("string.url | undefined"),
       POSTGRES_PRISMA_URL: type("string.url | undefined"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -104,7 +104,7 @@ export const supabaseVercel = (): Readonly<SupabaseVercelEnv> =>
       NEXT_PUBLIC_SUPABASE_ANON_KEY: type("string | undefined"),
       NEXT_PUBLIC_SUPABASE_URL: type("string.url | undefined"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -115,7 +115,7 @@ export const uploadthingV6 = (): Readonly<UploadThingV6Env> =>
     server: {
       UPLOADTHING_TOKEN: type("string"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -126,7 +126,7 @@ export const uploadthing = (): Readonly<UploadThingEnv> =>
     server: {
       UPLOADTHING_TOKEN: type("string"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -149,7 +149,7 @@ export const render = (): Readonly<RenderEnv> =>
       RENDER_SERVICE_TYPE: type("'web' | 'pserv' | 'cron' | 'worker' | 'static' | undefined"),
       RENDER: type("string | undefined"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -183,7 +183,7 @@ export const railway = (): Readonly<RailwayEnv> =>
       RAILWAY_GIT_REPO_OWNER: type("string | undefined"),
       RAILWAY_GIT_COMMIT_MESSAGE: type("string | undefined"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -205,7 +205,7 @@ export const fly = (): Readonly<FlyEnv> =>
       FLY_VM_MEMORY_MB: type("string | undefined"),
       PRIMARY_REGION: type("string | undefined"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -227,7 +227,7 @@ export const netlify = (): Readonly<NetlifyEnv> =>
       SITE_NAME: type("string | undefined"),
       SITE_ID: type("string | undefined"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -240,7 +240,7 @@ export const upstashRedis = (): Readonly<UpstashRedisEnv> =>
       UPSTASH_REDIS_REST_URL: type("string.url"),
       UPSTASH_REDIS_REST_TOKEN: type("string"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -259,7 +259,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
       PORT: type("string | undefined"),
       HOST: type("string | undefined"),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**

--- a/packages/core/src/presets-arktype.ts
+++ b/packages/core/src/presets-arktype.ts
@@ -21,6 +21,9 @@ import type {
   WxtEnv,
 } from "./presets.ts";
 
+const serverRuntimeEnv: Record<string, string | undefined> =
+  typeof process !== "undefined" ? process.env : {};
+
 /**
  * Vercel System Environment Variables
  * @see https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables
@@ -51,7 +54,7 @@ export const vercel = (): Readonly<VercelEnv> =>
       VERCEL_GIT_PREVIOUS_SHA: type("string | undefined"),
       VERCEL_GIT_PULL_REQUEST_ID: type("string | undefined"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -77,7 +80,7 @@ export const neonVercel = (): Readonly<NeonVercelEnv> =>
       POSTGRES_URL_NO_SSL: type("string.url | undefined"),
       POSTGRES_PRISMA_URL: type("string.url | undefined"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -101,7 +104,7 @@ export const supabaseVercel = (): Readonly<SupabaseVercelEnv> =>
       NEXT_PUBLIC_SUPABASE_ANON_KEY: type("string | undefined"),
       NEXT_PUBLIC_SUPABASE_URL: type("string.url | undefined"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -112,7 +115,7 @@ export const uploadthingV6 = (): Readonly<UploadThingV6Env> =>
     server: {
       UPLOADTHING_TOKEN: type("string"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -123,7 +126,7 @@ export const uploadthing = (): Readonly<UploadThingEnv> =>
     server: {
       UPLOADTHING_TOKEN: type("string"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -146,7 +149,7 @@ export const render = (): Readonly<RenderEnv> =>
       RENDER_SERVICE_TYPE: type("'web' | 'pserv' | 'cron' | 'worker' | 'static' | undefined"),
       RENDER: type("string | undefined"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -180,7 +183,7 @@ export const railway = (): Readonly<RailwayEnv> =>
       RAILWAY_GIT_REPO_OWNER: type("string | undefined"),
       RAILWAY_GIT_COMMIT_MESSAGE: type("string | undefined"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -202,7 +205,7 @@ export const fly = (): Readonly<FlyEnv> =>
       FLY_VM_MEMORY_MB: type("string | undefined"),
       PRIMARY_REGION: type("string | undefined"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -224,7 +227,7 @@ export const netlify = (): Readonly<NetlifyEnv> =>
       SITE_NAME: type("string | undefined"),
       SITE_ID: type("string | undefined"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -237,7 +240,7 @@ export const upstashRedis = (): Readonly<UpstashRedisEnv> =>
       UPSTASH_REDIS_REST_URL: type("string.url"),
       UPSTASH_REDIS_REST_TOKEN: type("string"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -256,7 +259,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
       PORT: type("string | undefined"),
       HOST: type("string | undefined"),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**

--- a/packages/core/src/presets-valibot.ts
+++ b/packages/core/src/presets-valibot.ts
@@ -21,7 +21,7 @@ import type {
   WxtEnv,
 } from "./presets.ts";
 
-const serverRuntimeEnv: Record<string, string | undefined> =
+const serverEnv = (): Record<string, string | undefined> =>
   typeof process !== "undefined" ? process.env : {};
 
 /**
@@ -54,7 +54,7 @@ export const vercel = (): Readonly<VercelEnv> =>
       VERCEL_GIT_PREVIOUS_SHA: optional(string()),
       VERCEL_GIT_PULL_REQUEST_ID: optional(string()),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -80,7 +80,7 @@ export const neonVercel = (): Readonly<NeonVercelEnv> =>
       POSTGRES_URL_NO_SSL: optional(pipe(string(), url())),
       POSTGRES_PRISMA_URL: optional(pipe(string(), url())),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -104,7 +104,7 @@ export const supabaseVercel = (): Readonly<SupabaseVercelEnv> =>
       NEXT_PUBLIC_SUPABASE_ANON_KEY: optional(string()),
       NEXT_PUBLIC_SUPABASE_URL: optional(pipe(string(), url())),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -115,7 +115,7 @@ export const uploadthingV6 = (): Readonly<UploadThingV6Env> =>
     server: {
       UPLOADTHING_TOKEN: string(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -126,7 +126,7 @@ export const uploadthing = (): Readonly<UploadThingEnv> =>
     server: {
       UPLOADTHING_TOKEN: string(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -149,7 +149,7 @@ export const render = (): Readonly<RenderEnv> =>
       RENDER_SERVICE_TYPE: optional(picklist(["web", "pserv", "cron", "worker", "static"])),
       RENDER: optional(string()),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -183,7 +183,7 @@ export const railway = (): Readonly<RailwayEnv> =>
       RAILWAY_GIT_REPO_OWNER: optional(string()),
       RAILWAY_GIT_COMMIT_MESSAGE: optional(string()),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -205,7 +205,7 @@ export const fly = (): Readonly<FlyEnv> =>
       FLY_VM_MEMORY_MB: optional(string()),
       PRIMARY_REGION: optional(string()),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -227,7 +227,7 @@ export const netlify = (): Readonly<NetlifyEnv> =>
       SITE_NAME: optional(string()),
       SITE_ID: optional(string()),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -240,7 +240,7 @@ export const upstashRedis = (): Readonly<UpstashRedisEnv> =>
       UPSTASH_REDIS_REST_URL: pipe(string(), url()),
       UPSTASH_REDIS_REST_TOKEN: string(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -259,7 +259,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
       PORT: optional(string()),
       HOST: optional(string()),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**

--- a/packages/core/src/presets-valibot.ts
+++ b/packages/core/src/presets-valibot.ts
@@ -21,6 +21,9 @@ import type {
   WxtEnv,
 } from "./presets.ts";
 
+const serverRuntimeEnv: Record<string, string | undefined> =
+  typeof process !== "undefined" ? process.env : {};
+
 /**
  * Vercel System Environment Variables
  * @see https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables
@@ -51,7 +54,7 @@ export const vercel = (): Readonly<VercelEnv> =>
       VERCEL_GIT_PREVIOUS_SHA: optional(string()),
       VERCEL_GIT_PULL_REQUEST_ID: optional(string()),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -77,7 +80,7 @@ export const neonVercel = (): Readonly<NeonVercelEnv> =>
       POSTGRES_URL_NO_SSL: optional(pipe(string(), url())),
       POSTGRES_PRISMA_URL: optional(pipe(string(), url())),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -101,7 +104,7 @@ export const supabaseVercel = (): Readonly<SupabaseVercelEnv> =>
       NEXT_PUBLIC_SUPABASE_ANON_KEY: optional(string()),
       NEXT_PUBLIC_SUPABASE_URL: optional(pipe(string(), url())),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -112,7 +115,7 @@ export const uploadthingV6 = (): Readonly<UploadThingV6Env> =>
     server: {
       UPLOADTHING_TOKEN: string(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -123,7 +126,7 @@ export const uploadthing = (): Readonly<UploadThingEnv> =>
     server: {
       UPLOADTHING_TOKEN: string(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -146,7 +149,7 @@ export const render = (): Readonly<RenderEnv> =>
       RENDER_SERVICE_TYPE: optional(picklist(["web", "pserv", "cron", "worker", "static"])),
       RENDER: optional(string()),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -180,7 +183,7 @@ export const railway = (): Readonly<RailwayEnv> =>
       RAILWAY_GIT_REPO_OWNER: optional(string()),
       RAILWAY_GIT_COMMIT_MESSAGE: optional(string()),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -202,7 +205,7 @@ export const fly = (): Readonly<FlyEnv> =>
       FLY_VM_MEMORY_MB: optional(string()),
       PRIMARY_REGION: optional(string()),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -224,7 +227,7 @@ export const netlify = (): Readonly<NetlifyEnv> =>
       SITE_NAME: optional(string()),
       SITE_ID: optional(string()),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -237,7 +240,7 @@ export const upstashRedis = (): Readonly<UpstashRedisEnv> =>
       UPSTASH_REDIS_REST_URL: pipe(string(), url()),
       UPSTASH_REDIS_REST_TOKEN: string(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -256,7 +259,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
       PORT: optional(string()),
       HOST: optional(string()),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**

--- a/packages/core/src/presets-zod.ts
+++ b/packages/core/src/presets-zod.ts
@@ -21,7 +21,7 @@ import type {
   WxtEnv,
 } from "./presets.ts";
 
-const serverRuntimeEnv: Record<string, string | undefined> =
+const serverEnv = (): Record<string, string | undefined> =>
   typeof process !== "undefined" ? process.env : {};
 
 /**
@@ -54,7 +54,7 @@ export const vercel = (): Readonly<VercelEnv> =>
       VERCEL_GIT_PREVIOUS_SHA: z.string().optional(),
       VERCEL_GIT_PULL_REQUEST_ID: z.string().optional(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -80,7 +80,7 @@ export const neonVercel = (): Readonly<NeonVercelEnv> =>
       POSTGRES_URL_NO_SSL: z.string().url().optional(),
       POSTGRES_PRISMA_URL: z.string().url().optional(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -104,7 +104,7 @@ export const supabaseVercel = (): Readonly<SupabaseVercelEnv> =>
       NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
       NEXT_PUBLIC_SUPABASE_URL: z.string().url().optional(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -115,7 +115,7 @@ export const uploadthingV6 = (): Readonly<UploadThingV6Env> =>
     server: {
       UPLOADTHING_TOKEN: z.string(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -126,7 +126,7 @@ export const uploadthing = (): Readonly<UploadThingEnv> =>
     server: {
       UPLOADTHING_TOKEN: z.string(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -149,7 +149,7 @@ export const render = (): Readonly<RenderEnv> =>
       RENDER_SERVICE_TYPE: z.enum(["web", "pserv", "cron", "worker", "static"]).optional(),
       RENDER: z.string().optional(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -183,7 +183,7 @@ export const railway = (): Readonly<RailwayEnv> =>
       RAILWAY_GIT_REPO_OWNER: z.string().optional(),
       RAILWAY_GIT_COMMIT_MESSAGE: z.string().optional(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -205,7 +205,7 @@ export const fly = (): Readonly<FlyEnv> =>
       FLY_VM_MEMORY_MB: z.string().optional(),
       PRIMARY_REGION: z.string().optional(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -227,7 +227,7 @@ export const netlify = (): Readonly<NetlifyEnv> =>
       SITE_NAME: z.string().optional(),
       SITE_ID: z.string().optional(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -240,7 +240,7 @@ export const upstashRedis = (): Readonly<UpstashRedisEnv> =>
       UPSTASH_REDIS_REST_URL: z.string().url(),
       UPSTASH_REDIS_REST_TOKEN: z.string(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**
@@ -259,7 +259,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
       PORT: z.string().optional(),
       HOST: z.string().optional(),
     },
-    runtimeEnv: serverRuntimeEnv,
+    runtimeEnv: serverEnv(),
   });
 
 /**

--- a/packages/core/src/presets-zod.ts
+++ b/packages/core/src/presets-zod.ts
@@ -21,6 +21,9 @@ import type {
   WxtEnv,
 } from "./presets.ts";
 
+const serverRuntimeEnv: Record<string, string | undefined> =
+  typeof process !== "undefined" ? process.env : {};
+
 /**
  * Vercel System Environment Variables
  * @see https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables
@@ -51,7 +54,7 @@ export const vercel = (): Readonly<VercelEnv> =>
       VERCEL_GIT_PREVIOUS_SHA: z.string().optional(),
       VERCEL_GIT_PULL_REQUEST_ID: z.string().optional(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -77,7 +80,7 @@ export const neonVercel = (): Readonly<NeonVercelEnv> =>
       POSTGRES_URL_NO_SSL: z.string().url().optional(),
       POSTGRES_PRISMA_URL: z.string().url().optional(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -101,7 +104,7 @@ export const supabaseVercel = (): Readonly<SupabaseVercelEnv> =>
       NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
       NEXT_PUBLIC_SUPABASE_URL: z.string().url().optional(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -112,7 +115,7 @@ export const uploadthingV6 = (): Readonly<UploadThingV6Env> =>
     server: {
       UPLOADTHING_TOKEN: z.string(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -123,7 +126,7 @@ export const uploadthing = (): Readonly<UploadThingEnv> =>
     server: {
       UPLOADTHING_TOKEN: z.string(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -146,7 +149,7 @@ export const render = (): Readonly<RenderEnv> =>
       RENDER_SERVICE_TYPE: z.enum(["web", "pserv", "cron", "worker", "static"]).optional(),
       RENDER: z.string().optional(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -180,7 +183,7 @@ export const railway = (): Readonly<RailwayEnv> =>
       RAILWAY_GIT_REPO_OWNER: z.string().optional(),
       RAILWAY_GIT_COMMIT_MESSAGE: z.string().optional(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -202,7 +205,7 @@ export const fly = (): Readonly<FlyEnv> =>
       FLY_VM_MEMORY_MB: z.string().optional(),
       PRIMARY_REGION: z.string().optional(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -224,7 +227,7 @@ export const netlify = (): Readonly<NetlifyEnv> =>
       SITE_NAME: z.string().optional(),
       SITE_ID: z.string().optional(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -237,7 +240,7 @@ export const upstashRedis = (): Readonly<UpstashRedisEnv> =>
       UPSTASH_REDIS_REST_URL: z.string().url(),
       UPSTASH_REDIS_REST_TOKEN: z.string(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**
@@ -256,7 +259,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
       PORT: z.string().optional(),
       HOST: z.string().optional(),
     },
-    runtimeEnv: process.env,
+    runtimeEnv: serverRuntimeEnv,
   });
 
 /**

--- a/packages/core/test/smoke-arktype.test.ts
+++ b/packages/core/test/smoke-arktype.test.ts
@@ -1,7 +1,7 @@
 import { type } from "arktype";
 import { describe, expect, expectTypeOf, test, vi } from "vitest";
 import { createEnv } from "../src/index.ts";
-import { uploadthing } from "../src/presets-arktype.ts";
+import { uploadthing, vercel } from "../src/presets-arktype.ts";
 
 function ignoreErrors(cb: () => void) {
   try {
@@ -803,4 +803,13 @@ test("with built-in preset", () => {
 
   expect(env.FOO).toBe("bar");
   expect(env.UPLOADTHING_TOKEN).toBe("token");
+});
+
+test("server presets do not throw when process is not defined", () => {
+  vi.stubGlobal("process", undefined);
+  try {
+    expect(() => vercel()).not.toThrow();
+  } finally {
+    vi.unstubAllGlobals();
+  }
 });

--- a/packages/core/test/smoke-valibot.test.ts
+++ b/packages/core/test/smoke-valibot.test.ts
@@ -1,7 +1,7 @@
 import * as v from "valibot";
 import { describe, expect, expectTypeOf, test, vi } from "vitest";
 import { createEnv } from "../src/index.ts";
-import { uploadthing } from "../src/presets-valibot.ts";
+import { uploadthing, vercel } from "../src/presets-valibot.ts";
 
 function ignoreErrors(cb: () => void) {
   try {
@@ -802,4 +802,13 @@ test("with built-in preset", () => {
 
   expect(env.FOO).toBe("bar");
   expect(env.UPLOADTHING_TOKEN).toBe("token");
+});
+
+test("server presets do not throw when process is not defined", () => {
+  vi.stubGlobal("process", undefined);
+  try {
+    expect(() => vercel()).not.toThrow();
+  } finally {
+    vi.unstubAllGlobals();
+  }
 });

--- a/packages/core/test/smoke-zod3.test.ts
+++ b/packages/core/test/smoke-zod3.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, expectTypeOf, test, vi } from "vitest";
 
 import * as z from "zod/v3";
 import { createEnv } from "../src/index.ts";
-import { uploadthing } from "../src/presets-zod.ts";
+import { uploadthing, vercel } from "../src/presets-zod.ts";
 
 function ignoreErrors(cb: () => void) {
   try {
@@ -807,4 +807,13 @@ test("with built-in preset", () => {
 
   expect(env.FOO).toBe("bar");
   expect(env.UPLOADTHING_TOKEN).toBe("token");
+});
+
+test("server presets do not throw when process is not defined", () => {
+  vi.stubGlobal("process", undefined);
+  try {
+    expect(() => vercel()).not.toThrow();
+  } finally {
+    vi.unstubAllGlobals();
+  }
 });

--- a/packages/core/test/smoke-zod4.test.ts
+++ b/packages/core/test/smoke-zod4.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, test, vi } from "vitest";
 import * as z from "zod/v4";
 import { createEnv } from "../src/index.ts";
-import { uploadthing } from "../src/presets-zod.ts";
+import { uploadthing, vercel } from "../src/presets-zod.ts";
 
 function ignoreErrors(cb: () => void) {
   try {
@@ -806,4 +806,13 @@ test("with built-in preset", () => {
 
   expect(env.FOO).toBe("bar");
   expect(env.UPLOADTHING_TOKEN).toBe("token");
+});
+
+test("server presets do not throw when process is not defined", () => {
+  vi.stubGlobal("process", undefined);
+  try {
+    expect(() => vercel()).not.toThrow();
+  } finally {
+    vi.unstubAllGlobals();
+  }
 });


### PR DESCRIPTION
## Problem

Calling any server preset (`vercel()`, `uploadthing()`, `railway()`, etc.) in a browser environment without a `process` polyfill crashes with:

```
Uncaught ReferenceError: process is not defined
    vercel presets-zod.js:43
```

This happens because the preset functions call `createEnv({ runtimeEnv: process.env, ... })`, and `process.env` is evaluated at call time, before any guard can fire.

Fixes #407.

## Fix

Each preset file (`presets-zod.ts`, `presets-arktype.ts`, `presets-valibot.ts`) now defines a private getter:

```ts
const serverEnv = (): Record<string, string | undefined> =>
  typeof process !== "undefined" ? process.env : {};
```

Each server preset passes `serverEnv()` as `runtimeEnv`. The function is called at preset invocation time, so:
- In Node.js / Bun / Deno: returns `process.env` as before
- In browsers without a `process` polyfill: returns `{}` — all preset env vars are optional, so validation passes

`vite` and `wxt` presets already use `import.meta.env` and are unchanged.

The same guard is applied to the `runtimeEnv` fallback inside `createEnv` (`packages/core/src/index.ts`), protecting against the case where a caller omits `runtimeEnv` entirely in a browser context.

## Why not a module-level constant?

A module-level `const serverRuntimeEnv = typeof process !== "undefined" ? process.env : {}` evaluates at import time. The test suite reassigns `process.env` inside a `describe` block, which runs during collection after imports complete, so a const captures a stale reference and breaks the existing `"with built-in preset"` test.

## Tests

Regression tests added to all four smoke suites (zod v3, zod v4, arktype, valibot):

```ts
test("server presets do not throw when process is not defined", () => {
  vi.stubGlobal("process", undefined);
  try {
    expect(() => vercel()).not.toThrow();
  } finally {
    vi.unstubAllGlobals();
  }
});
```

This test fails on pre-fix code (accessing `process.env` where `process` is `undefined` throws `TypeError`) and passes on the fix.