### PR TITLE
fix(core): avoid mutating runtimeEnv when emptyStringAsUndefined is true

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -312,16 +312,14 @@ export function createEnv<
 >(
   opts: EnvOptions<TPrefix, TServer, TClient, TShared, TExtends, TFinalSchema>,
 ): CreateEnv<TFinalSchema, TExtends> {
-  const runtimeEnv = opts.runtimeEnvStrict ?? opts.runtimeEnv ?? process.env;
+  const rawRuntimeEnv = opts.runtimeEnvStrict ?? opts.runtimeEnv ?? process.env;
 
   const emptyStringAsUndefined = opts.emptyStringAsUndefined ?? false;
-  if (emptyStringAsUndefined) {
-    for (const [key, value] of Object.entries(runtimeEnv)) {
-      if (value === "") {
-        delete runtimeEnv[key];
-      }
-    }
-  }
+  const runtimeEnv = emptyStringAsUndefined
+    ? (Object.fromEntries(
+        Object.entries(rawRuntimeEnv).filter(([, v]) => v !== ""),
+      ) as typeof rawRuntimeEnv)
+    : rawRuntimeEnv;
 
   const skip = !!opts.skipValidation;
   if (skip) {

--- a/packages/core/test/smoke-zod4.test.ts
+++ b/packages/core/test/smoke-zod4.test.ts
@@ -807,3 +807,37 @@ test("with built-in preset", () => {
   expect(env.FOO).toBe("bar");
   expect(env.UPLOADTHING_TOKEN).toBe("token");
 });
+
+describe("emptyStringAsUndefined", () => {
+  test("does not mutate the runtimeEnv object", () => {
+    const env: Record<string, string> = { EMPTY: "", PRESENT: "hello" };
+
+    createEnv({
+      server: { PRESENT: z.string() },
+      runtimeEnv: env,
+      emptyStringAsUndefined: true,
+    });
+
+    expect(env).toHaveProperty("EMPTY", "");
+  });
+
+  test("treats empty strings as undefined — required field fails validation", () => {
+    expect(() =>
+      createEnv({
+        server: { REQUIRED: z.string() },
+        runtimeEnv: { REQUIRED: "" },
+        emptyStringAsUndefined: true,
+      }),
+    ).toThrow();
+  });
+
+  test("applies schema default when env var is an empty string", () => {
+    const env = createEnv({
+      server: { WITH_DEFAULT: z.string().default("fallback") },
+      runtimeEnv: { WITH_DEFAULT: "" },
+      emptyStringAsUndefined: true,
+    });
+
+    expect(env.WITH_DEFAULT).toBe("fallback");
+  });
+});


### PR DESCRIPTION
When `emptyStringAsUndefined: true` is set, the current implementation iterates over `runtimeEnv` and calls `delete runtimeEnv[key]` for every empty-string entry. If the caller passes `process.env` (the most common pattern), this permanently removes those keys from the **global** `process.env` object for the lifetime of the process.

**Reproduction**

```ts
process.env.DATABASE_URL = "";

createEnv({
  server: { DATABASE_URL: z.string().optional() },
  runtimeEnv: process.env,
  emptyStringAsUndefined: true,
});

console.log("DATABASE_URL" in process.env); // false — key was deleted
```

Any code that reads `process.env.DATABASE_URL` after `createEnv` (e.g. Prisma, a logger, another `createEnv` call) sees `undefined` instead of `""`. The effect is silent and hard to debug.

**Fix**

Build a filtered copy of the env object instead of mutating it in place:

```ts
// before
const runtimeEnv = opts.runtimeEnvStrict ?? opts.runtimeEnv ?? process.env;
if (emptyStringAsUndefined) {
  for (const [key, value] of Object.entries(runtimeEnv)) {
    if (value === "") {
      delete runtimeEnv[key];
    }
  }
}

// after
const rawRuntimeEnv = opts.runtimeEnvStrict ?? opts.runtimeEnv ?? process.env;
const runtimeEnv = emptyStringAsUndefined
  ? (Object.fromEntries(
      Object.entries(rawRuntimeEnv).filter(([, v]) => v !== ""),
    ) as typeof rawRuntimeEnv)
  : rawRuntimeEnv;
```

The original `runtimeEnv` / `process.env` reference is never touched.

Tests added (in `packages/core/test/smoke-zod4.test.ts`):

- Verifies the passed object is not mutated after `createEnv`
- Verifies empty strings are still treated as undefined in validation (required field throws)
- Verifies schema defaults are applied when the env var is an empty string