### PR TITLE
fix(preset): update Vite preset to include env variables in both server and client

### DIFF
--- a/.changeset/strong-states-ring.md
+++ b/.changeset/strong-states-ring.md
@@ -1,0 +1,5 @@
+---
+"@t3-oss/env-core": patch
+---
+
+Update Vite preset to include env variables in both server and client

--- a/packages/core/src/presets-arktype.ts
+++ b/packages/core/src/presets-arktype.ts
@@ -265,7 +265,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
  */
 export const vite = (): Readonly<ViteEnv> =>
   createEnv({
-    server: {
+    shared: {
       BASE_URL: type("string"),
       MODE: type("string"),
       DEV: type("boolean"),

--- a/packages/core/src/presets-valibot.ts
+++ b/packages/core/src/presets-valibot.ts
@@ -265,7 +265,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
  */
 export const vite = (): Readonly<ViteEnv> =>
   createEnv({
-    server: {
+    shared: {
       BASE_URL: string(),
       MODE: string(),
       DEV: boolean(),

--- a/packages/core/src/presets-zod.ts
+++ b/packages/core/src/presets-zod.ts
@@ -265,7 +265,7 @@ export const coolify = (): Readonly<CoolifyEnv> =>
  */
 export const vite = (): Readonly<ViteEnv> =>
   createEnv({
-    server: {
+    shared: {
       BASE_URL: z.string(),
       MODE: z.string(),
       DEV: z.boolean(),


### PR DESCRIPTION
- Update Vite preset to include env variables in both server and client (shared)

Per Vite's documentation on [Env Variables and Modes](https://vite.dev/guide/env-and-mode) (bold mine):

> Some built-in constants are available **in all cases**:

